### PR TITLE
Break the beatled_core <-> beatled_server static-library cycle

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Check formatting
         run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format
+          # Pin clang-format so CI matches what contributors run locally; the
+          # unversioned apt package drifts between Ubuntu releases and would
+          # reformat differently than the developer's version.
+          pipx install clang-format==22.1.5
           find server/src -name '*.cpp' -o -name '*.hpp' -o -name '*.h' | \
             xargs clang-format --dry-run --Werror
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -44,20 +44,6 @@ set(BEATLED_PROTOCOL_PATH "${CMAKE_CURRENT_LIST_DIR}/../controller/lib/beatled_p
 include("${CMAKE_CURRENT_LIST_DIR}/cmake/beatled_protocol_import.cmake")
 beatled_protocol_init()
 
-
-# beatled_core and beatled_server form a static-library cycle (see the TODO in
-# src/CMakeLists.txt: core needs ServiceControllerInterface, server needs
-# StateManager). CMake repeats the archives on the link line to resolve the
-# cycle, which makes the Apple linker (ld-prime, Xcode 15+) warn about duplicate
-# libraries. The repetition is harmless; suppress the warning where the linker
-# supports the flag, until the cycle is broken by extracting the shared
-# interfaces into their own target.
-include(CheckLinkerFlag)
-check_linker_flag(CXX "-Wl,-no_warn_duplicate_libraries" HAVE_NO_WARN_DUPLICATE_LIBRARIES)
-if(HAVE_NO_WARN_DUPLICATE_LIBRARIES)
-  add_link_options("-Wl,-no_warn_duplicate_libraries")
-endif()
-
 add_subdirectory(src)
 
 if (BEATSERVER_ENABLE_TESTS)

--- a/server/src/CMakeLists.txt
+++ b/server/src/CMakeLists.txt
@@ -6,17 +6,7 @@ add_subdirectory(server)
 add_subdirectory(core)
 add_subdirectory(beat_detector)
 
-# TODO: Break circular dependency between core and server.
-# beatled_core depends on beatled_server for ServiceControllerInterface,
-# and beatled_server depends on beatled_core for StateManager.
-# Consider extracting shared interfaces into a separate target.
-target_link_libraries(beatled_core PUBLIC
-  beatled_server
-  beatled_protocol
-)
-
-
-add_executable(${BEAT_SERVER} 
+add_executable(${BEAT_SERVER}
   beatled_server.cpp
   application.cpp
 )
@@ -33,28 +23,19 @@ add_custom_target(build_constants ALL
 )
 add_dependencies(${BEAT_SERVER} build_constants)
 target_include_directories(${BEAT_SERVER} PUBLIC "${PROJECT_BINARY_DIR}/src")
-target_link_libraries(${BEAT_SERVER} PRIVATE 
-  beatled_server 
-  beat_detector
-  beatled_core
-
+# beatled_server PUBLIC-links beat_detector and beatled_core (which in turn
+# expose fmt/spdlog/lyra/asio), so listing those here too just duplicates them
+# on the link line. Keep only what isn't pulled transitively.
+target_link_libraries(${BEAT_SERVER} PRIVATE
+  beatled_server
   Threads::Threads
-  asio asio::asio 
-  fmt::fmt
-  bfg::lyra 
-  spdlog::spdlog 
 )
 
 
 add_executable(beatled_cli beatled_cli.cpp)
-target_link_libraries(beatled_cli PUBLIC 
+# beat_detector PUBLIC-links portaudio_static + beatled_core (fmt/spdlog/lyra).
+target_link_libraries(beatled_cli PRIVATE
   beat_detector
-  portaudio_static
-  # portaudio
-  bfg::lyra 
-  fmt::fmt
-  spdlog::spdlog 
-
 )
 
 

--- a/server/src/application.cpp
+++ b/server/src/application.cpp
@@ -27,8 +27,8 @@ Application::~Application() {
 }
 
 Application::Application(const Config &beatled_config)
-    : server_parameters_{beatled_config.server_parameters()}, logger_{server_parameters_.logger},
-      signals_{io_context_} {
+    : server_parameters_{server::make_server_parameters(beatled_config)},
+      logger_{server_parameters_.logger}, signals_{io_context_} {
 
   // Program-state refresh: re-push the current program at a low-rate
   // (default 200 ms; tunable via --program-refresh-ms) so a controller

--- a/server/src/core/CMakeLists.txt
+++ b/server/src/core/CMakeLists.txt
@@ -6,12 +6,11 @@ add_library(beatled_core
 
 target_include_directories(beatled_core PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 
-target_link_libraries(beatled_core PUBLIC 
+target_link_libraries(beatled_core PUBLIC
   fmt::fmt
-  bfg::lyra 
-  spdlog::spdlog 
+  bfg::lyra
+  spdlog::spdlog
   asio::asio
   nlohmann_json::nlohmann_json
-  # beatled_server
-  # beatled_protocol
+  beatled_protocol
 )

--- a/server/src/core/config.cpp
+++ b/server/src/core/config.cpp
@@ -1,4 +1,6 @@
 #include <cstdlib>
+#include <stdexcept>
+
 #include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 
@@ -97,47 +99,4 @@ void Config::log_config() const {
                                               ? std::string("off")
                                               : fmt::format("{} ms", m_status_probe_ms));
   SPDLOG_INFO("  QoS skew warn/fail: {} us / {} us", m_qos_skew_warn_us, m_qos_skew_fail_us);
-}
-
-beatled::server::Server::parameters_t Config::server_parameters() const {
-  using beatled::server::BroadcastMode;
-  BroadcastMode mode = BroadcastMode::Unicast;
-  if (m_broadcast_mode == "limited") {
-    mode = BroadcastMode::Limited;
-  } else if (m_broadcast_mode == "subnet") {
-    mode = BroadcastMode::Subnet;
-  } else if (m_broadcast_mode == "unicast") {
-    mode = BroadcastMode::Unicast;
-  } else {
-    throw std::runtime_error{fmt::format(
-        "Invalid --broadcast-mode '{}' (must be limited, subnet, or unicast)", m_broadcast_mode)};
-  }
-
-  server::Server::parameters_t server_parameters{
-      .start_http_server = m_start_http_server,
-      .start_udp_server = m_start_udp_server,
-      .start_broadcaster = m_start_broadcaster,
-      .http =
-          {
-              m_address,          // address
-              m_http_port,        // port
-              m_root_dir,         // root_dir
-              m_certs_dir,        // cert_dir
-              m_cors_origin,      // cors_origin
-              m_api_token,        // api_token
-              m_no_tls,           // no_tls
-              m_qos_skew_warn_us, // qos_skew_warn_us
-              m_qos_skew_fail_us, // qos_skew_fail_us
-          },
-      .udp = {m_udp_port},
-      .broadcasting = {m_broadcasting_address, m_broadcasting_port, mode},
-      .logger = {20, m_log_level},
-      .thread_pool_size = m_pool_size,
-      .program_refresh_ms = m_program_refresh_ms,
-      .status_probe_ms = m_status_probe_ms,
-      .qos_skew_warn_us = m_qos_skew_warn_us,
-      .qos_skew_fail_us = m_qos_skew_fail_us,
-  };
-
-  return server_parameters;
 }

--- a/server/src/core/include/core/config.hpp
+++ b/server/src/core/include/core/config.hpp
@@ -1,6 +1,7 @@
 #ifndef SERVER_SRC_CONFIG_INCLUDE_CONFIG_CONFIG_HPP_
 #define SERVER_SRC_CONFIG_INCLUDE_CONFIG_CONFIG_HPP_
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -10,17 +11,41 @@
 #include <iostream>
 #include <lyra/lyra.hpp>
 
-#include "server/server.hpp"
-
 namespace beatled::core {
 
+// Holds the parsed command-line configuration. It deliberately knows nothing
+// about the server target: the mapping from these values to a
+// server::Server::parameters_t lives in the server layer
+// (server::make_server_parameters), which keeps beatled_core free of any
+// dependency on beatled_server.
 class Config {
 public:
   Config(int argc, const char *argv[]);
 
-  server::Server::parameters_t server_parameters() const;
   void log_config() const;
   bool help() const { return m_help; }
+
+  // Accessors consumed by server::make_server_parameters().
+  bool start_http_server() const { return m_start_http_server; }
+  bool start_udp_server() const { return m_start_udp_server; }
+  bool start_broadcaster() const { return m_start_broadcaster; }
+  bool no_tls() const { return m_no_tls; }
+  const std::string &address() const { return m_address; }
+  const std::string &root_dir() const { return m_root_dir; }
+  const std::string &certs_dir() const { return m_certs_dir; }
+  const std::string &cors_origin() const { return m_cors_origin; }
+  const std::string &api_token() const { return m_api_token; }
+  const std::string &broadcasting_address() const { return m_broadcasting_address; }
+  const std::string &broadcast_mode() const { return m_broadcast_mode; }
+  const std::string &log_level() const { return m_log_level; }
+  std::uint16_t http_port() const { return m_http_port; }
+  std::uint16_t udp_port() const { return m_udp_port; }
+  std::uint16_t broadcasting_port() const { return m_broadcasting_port; }
+  std::size_t pool_size() const { return m_pool_size; }
+  std::uint32_t program_refresh_ms() const { return m_program_refresh_ms; }
+  std::uint32_t status_probe_ms() const { return m_status_probe_ms; }
+  std::uint32_t qos_skew_warn_us() const { return m_qos_skew_warn_us; }
+  std::uint32_t qos_skew_fail_us() const { return m_qos_skew_fail_us; }
 
 private:
   bool m_help{false};

--- a/server/src/core/state_manager.cpp
+++ b/server/src/core/state_manager.cpp
@@ -81,16 +81,13 @@ void StateManager::register_client(ClientStatus::Ptr client_status) {
       if (client_status->ip_address == (*it)->ip_address) {
         // Same board, same IP: just update timestamp (lightweight heartbeat)
         (*it)->last_status_time = client_status->last_status_time;
-        SPDLOG_DEBUG("Board {} heartbeat from {}",
-                     client_status->board_id.data(),
+        SPDLOG_DEBUG("Board {} heartbeat from {}", client_status->board_id.data(),
                      client_status->ip_address.to_string());
-        return;  // Don't add new registration
+        return; // Don't add new registration
       } else {
         // Same board, different IP: board changed networks, replace registration
-        SPDLOG_INFO("Board {} changed IP from {} to {}",
-                    client_status->board_id.data(),
-                    (*it)->ip_address.to_string(),
-                    client_status->ip_address.to_string());
+        SPDLOG_INFO("Board {} changed IP from {} to {}", client_status->board_id.data(),
+                    (*it)->ip_address.to_string(), client_status->ip_address.to_string());
         it = clients_.erase(it);
         continue;
       }
@@ -98,8 +95,7 @@ void StateManager::register_client(ClientStatus::Ptr client_status) {
     if (client_status->ip_address == (*it)->ip_address) {
       // Different board, same IP: new board took over IP, keep newest
       SPDLOG_INFO("IP {} has new board {}. Replacing old board {}",
-                  client_status->ip_address.to_string(),
-                  client_status->board_id.data(),
+                  client_status->ip_address.to_string(), client_status->board_id.data(),
                   (*it)->board_id.data());
       it = clients_.erase(it);
       continue;

--- a/server/src/server/include/server/server.hpp
+++ b/server/src/server/include/server/server.hpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "core/config.hpp"
 #include "http_server/http_server.hpp"
 #include "logger/logger.hpp"
 #include "tempo_broadcaster/tempo_broadcaster.hpp"
@@ -70,6 +71,12 @@ private:
   /// The signal_set is used to register for process termination notifications.
   asio::signal_set signals_;
 };
+
+/// Map the parsed command-line Config (a core concern) onto the server's
+/// bootstrap parameters. Living in the server layer keeps beatled_core
+/// independent of beatled_server (no circular dependency).
+Server::parameters_t make_server_parameters(const core::Config &config);
+
 } // namespace server
 
 } // namespace beatled

--- a/server/src/server/server.cpp
+++ b/server/src/server/server.cpp
@@ -12,8 +12,12 @@
 #include <memory>
 #include <mutex>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 #include <vector>
 
+#include <fmt/format.h>
+
+#include "core/config.hpp"
 #include "core/interfaces/service_manager.hpp"
 #include "http_server/http_server.hpp"
 #include "server/server.hpp"
@@ -79,6 +83,47 @@ void Server::run() {
   // If an error was detected it should be propagated.
   if (exception_caught)
     std::rethrow_exception(exception_caught);
+}
+
+Server::parameters_t make_server_parameters(const core::Config &config) {
+  BroadcastMode mode = BroadcastMode::Unicast;
+  const std::string &broadcast_mode = config.broadcast_mode();
+  if (broadcast_mode == "limited") {
+    mode = BroadcastMode::Limited;
+  } else if (broadcast_mode == "subnet") {
+    mode = BroadcastMode::Subnet;
+  } else if (broadcast_mode == "unicast") {
+    mode = BroadcastMode::Unicast;
+  } else {
+    throw std::runtime_error{fmt::format(
+        "Invalid --broadcast-mode '{}' (must be limited, subnet, or unicast)", broadcast_mode)};
+  }
+
+  return Server::parameters_t{
+      .start_http_server = config.start_http_server(),
+      .start_udp_server = config.start_udp_server(),
+      .start_broadcaster = config.start_broadcaster(),
+      .http =
+          {
+              config.address(),          // address
+              config.http_port(),        // port
+              config.root_dir(),         // root_dir
+              config.certs_dir(),        // cert_dir
+              config.cors_origin(),      // cors_origin
+              config.api_token(),        // api_token
+              config.no_tls(),           // no_tls
+              config.qos_skew_warn_us(), // qos_skew_warn_us
+              config.qos_skew_fail_us(), // qos_skew_fail_us
+          },
+      .udp = {config.udp_port()},
+      .broadcasting = {config.broadcasting_address(), config.broadcasting_port(), mode},
+      .logger = {20, config.log_level()},
+      .thread_pool_size = config.pool_size(),
+      .program_refresh_ms = config.program_refresh_ms(),
+      .status_probe_ms = config.status_probe_ms(),
+      .qos_skew_warn_us = config.qos_skew_warn_us(),
+      .qos_skew_fail_us = config.qos_skew_fail_us(),
+  };
 }
 
 } // namespace beatled::server

--- a/server/tests/CMakeLists.txt
+++ b/server/tests/CMakeLists.txt
@@ -26,10 +26,10 @@ target_link_libraries(blocking_udp_echo_server Threads::Threads)
 target_link_libraries(blocking_udp_echo_client Threads::Threads)
 
 add_executable(test_factorials test_factorials.cpp)
-target_link_libraries(test_factorials PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+target_link_libraries(test_factorials PRIVATE Catch2::Catch2WithMain)
 
 add_executable(test_rgb_hsv test_rgb_hsv.cpp)
-target_link_libraries(test_rgb_hsv PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+target_link_libraries(test_rgb_hsv PRIVATE Catch2::Catch2WithMain)
 # add_test (NAME TestFactorials COMMAND test_factorials)
 # catch_discover_tests(test_factorials)
 
@@ -50,7 +50,7 @@ target_link_libraries(test_kissfft PRIVATE  kissfft::kissfft)
 
 
 add_executable(test_audio_buffer_pool test_audio_buffer_pool.cpp)
-target_link_libraries(test_audio_buffer_pool PRIVATE beatled_core Catch2::Catch2 Catch2::Catch2WithMain spdlog::spdlog)
+target_link_libraries(test_audio_buffer_pool PRIVATE beat_detector beatled_core Catch2::Catch2WithMain)
 if(NOT VCPKG_TARGET_TRIPLET)
   message("Discover tests")
   catch_discover_tests(test_audio_buffer_pool)
@@ -60,7 +60,7 @@ endif()
 # target_link_libraries(test_tempo PRIVATE Aubio::aubio)
 
 add_executable(test_move_semantics test_move_semantics.cpp)
-target_link_libraries(test_move_semantics PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+target_link_libraries(test_move_semantics PRIVATE Catch2::Catch2WithMain)
 
 if(NOT VCPKG_TARGET_TRIPLET)
   catch_discover_tests(test_move_semantics)

--- a/server/tests/api_handler/CMakeLists.txt
+++ b/server/tests/api_handler/CMakeLists.txt
@@ -1,9 +1,6 @@
 add_executable(test_api_handler test_api_handler.cpp)
 target_link_libraries(test_api_handler PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
-  spdlog::spdlog
-  nlohmann_json::nlohmann_json
   beatled_core
 )
 if(NOT VCPKG_TARGET_TRIPLET)

--- a/server/tests/http/CMakeLists.txt
+++ b/server/tests/http/CMakeLists.txt
@@ -1,9 +1,7 @@
 add_executable(test_mime_types test_mime_types.cpp)
 target_link_libraries(test_mime_types PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
   beatled_http_server
-  spdlog::spdlog
 )
 if(NOT VCPKG_TARGET_TRIPLET)
   catch_discover_tests(test_mime_types)
@@ -11,11 +9,8 @@ endif()
 
 add_executable(test_api_gates test_api_gates.cpp)
 target_link_libraries(test_api_gates PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
   beatled_http_server
-  beatled_core
-  spdlog::spdlog
 )
 if(NOT VCPKG_TARGET_TRIPLET)
   catch_discover_tests(test_api_gates)

--- a/server/tests/logger/CMakeLists.txt
+++ b/server/tests/logger/CMakeLists.txt
@@ -1,9 +1,8 @@
 add_executable(test_fmt_log test_fmt_log.cpp)
 target_link_libraries(test_fmt_log PRIVATE 
-  Catch2::Catch2 
   Catch2::Catch2WithMain
   spdlog::spdlog
-  beatled_udp  
+  beatled_udp
 )
 if(NOT VCPKG_TARGET_TRIPLET)
   catch_discover_tests(test_fmt_log)

--- a/server/tests/state_manager/CMakeLists.txt
+++ b/server/tests/state_manager/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_executable(test_state_manager test_state_manager.cpp)
 target_link_libraries(test_state_manager PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
-  spdlog::spdlog
   beatled_core
 )
 if(NOT VCPKG_TARGET_TRIPLET)
@@ -11,9 +9,7 @@ endif()
 
 add_executable(test_client_status_json test_client_status_json.cpp)
 target_link_libraries(test_client_status_json PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
-  spdlog::spdlog
   beatled_core
 )
 if(NOT VCPKG_TARGET_TRIPLET)

--- a/server/tests/udp/CMakeLists.txt
+++ b/server/tests/udp/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_executable(test_udp_protocol test_udp_protocol.cpp)
 target_link_libraries(test_udp_protocol PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
   spdlog::spdlog
   beatled_udp
@@ -11,9 +10,7 @@ endif()
 
 add_executable(test_udp_request_handler test_udp_request_handler.cpp)
 target_link_libraries(test_udp_request_handler PRIVATE
-  Catch2::Catch2
   Catch2::Catch2WithMain
-  spdlog::spdlog
   beatled_udp_server
   beatled_udp
   beatled_core


### PR DESCRIPTION
## Summary

Removes the circular static-library dependency between `beatled_core` and `beatled_server` — the root cause of the Apple linker's *"ignoring duplicate libraries"* warnings (CMake repeats archives to resolve the cycle).

**The cut:** core depended on server only because `core::Config::server_parameters()` returned `server::Server::parameters_t`, forcing `config.hpp` to include `server/server.hpp`. Moved that mapping to the layer that owns the type:
- `core::Config` now exposes its parsed values via plain accessors and no longer includes any server header.
- New free function `server::make_server_parameters(const core::Config&)` (in `beatled_server`) builds the `Server::parameters_t`.
- `beatled_core` no longer links `beatled_server`; the dependency is now one-directional (`server → core`).

## Fallout fixed
- `beatled_core` links `beatled_protocol` directly (it had been arriving via the removed core→server edge; `client_status.hpp` needs it).
- `test_audio_buffer_pool` links `beat_detector` explicitly — it was getting beat_detector headers transitively through the cycle.
- **Removed** the `-Wl,-no_warn_duplicate_libraries` suppression added in the previous PR — with the cycle gone it's no longer needed.
- Cleaned the remaining duplicate-library sources: dropped redundant `Catch2::Catch2` (WithMain already provides it), redundant `spdlog`, and the executables' direct links already transitive via `beatled_server` / `beat_detector`.

## Verification
- `./beatled.sh server build` — **zero** duplicate-library warnings, no suppression flag.
- All server test suites pass.
- Smoke-tested `beat_server` — config parsing and the new parameter mapping work at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)