### PR TITLE
Fix pico cross-build: use %llu/%lld instead of PRIu64/PRId64

### DIFF
--- a/controller/src/command/hello/hello.c
+++ b/controller/src/command/hello/hello.c
@@ -54,8 +54,8 @@ int send_hello_request() {
     printf("[NET] Sending hello request (state=%s, no response yet)\n", state_name(st));
   } else {
     uint64_t since_us = time_us_64() - last_hello_response_us;
-    printf("[NET] Sending hello request (state=%s, last response %" PRIu64 "s ago)\n",
-           state_name(st), since_us / 1000000ULL);
+    printf("[NET] Sending hello request (state=%s, last response %llus ago)\n", state_name(st),
+           (unsigned long long)(since_us / 1000000ULL));
   }
   int err = send_udp_request(sizeof(beatled_message_hello_request_t), prepare_hello_request);
   if (err) {

--- a/controller/src/command/time/time.c
+++ b/controller/src/command/time/time.c
@@ -184,8 +184,8 @@ int process_time_msg(beatled_message_t *server_msg, size_t data_length, uint64_t
   // orig_time doesn't match the most-recently-sent one, this is a delayed
   // response from a prior request — applying it would corrupt the offset.
   if (!have_outstanding_request || orig_time != outstanding_orig_time) {
-    printf("[CMD] Stale TIME_RESPONSE orig=%" PRIu64 " (expected %" PRIu64 "), dropping\n",
-           orig_time, outstanding_orig_time);
+    printf("[CMD] Stale TIME_RESPONSE orig=%llu (expected %llu), dropping\n",
+           (unsigned long long)orig_time, (unsigned long long)outstanding_orig_time);
     return 0;
   }
   have_outstanding_request = false;
@@ -208,9 +208,10 @@ int process_time_msg(beatled_message_t *server_msg, size_t data_length, uint64_t
   uint64_t threshold = med_delay * 2 > med_delay ? med_delay * 2 : UINT64_MAX;
   int64_t med_offset = median_offset_excluding_outliers(threshold);
 
-  printf("[CMD] Time sync: delay=%" PRIu64 "us offset=%" PRId64 "us "
-         "(med_delay=%" PRIu64 "us med_offset=%" PRId64 "us n=%zu)\n",
-         delay, clock_offset, med_delay, med_offset, valid_sample_count);
+  printf("[CMD] Time sync: delay=%lluus offset=%lldus "
+         "(med_delay=%lluus med_offset=%lldus n=%zu)\n",
+         (unsigned long long)delay, (long long)clock_offset, (unsigned long long)med_delay,
+         (long long)med_offset, valid_sample_count);
 
   set_server_time_offset(med_offset);
 


### PR DESCRIPTION
## Summary

The `Build pico .uf2` CI jobs fail to compile `hello.c` and `time.c`:
`error: expected ')' before 'PRIu64'`. The `arm-none-eabi` newlib used by the cross-build doesn't define the 64-bit `inttypes` format macros the way the host toolchains do.

Notably the 32-bit macros (`PRIu32`) and the rest of the firmware are fine — only these two files used `PRIu64`/`PRId64`, and they're the odd ones out: the codebase already prints 64-bit values with `%llu` elsewhere (e.g. `ws2812.c`).

## Change
Match the existing convention — print `uint64_t`/`int64_t` via `%llu`/`%lld` with explicit `(unsigned long long)`/`(long long)` casts, portable across host and `arm-none-eabi`.

## Verification
- Local `arm-none-eabi` **pico** and **pico_freertos** hardware builds both produce a `.uf2` (previously failed here).
- `./beatled.sh test pico` (POSIX firmware tests) still pass.

This is the firmware half of the controller CI fixes; the POSIX-simulator CI half landed in #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)