### PR TITLE
Fix inter-controller beat skew: OWD double-count, Wi-Fi power-save, frame alignment, skew metric

### DIFF
--- a/controller/src/hal/wifi/ports/pico/wifi.c
+++ b/controller/src/hal/wifi/ports/pico/wifi.c
@@ -5,14 +5,20 @@
 #include "hal/wifi.h"
 
 int wifi_connect(const char *wifi_ssid, const char *wifi_password) {
-  if (cyw43_arch_wifi_connect_blocking(wifi_ssid, wifi_password,
-                                       CYW43_AUTH_WPA2_AES_PSK)) {
+  if (cyw43_arch_wifi_connect_blocking(wifi_ssid, wifi_password, CYW43_AUTH_WPA2_AES_PSK)) {
     // blink(ERROR_BLINK_SPEED, ERROR_WIFI);
     puts("[ERR] Failed to connect to WiFi");
     return 1;
   }
   printf("[NET] Connected to %s\n", wifi_ssid);
   // blink(MESSAGE_BLINK_SPEED, MESSAGE_CONNECTED);
+
+  // Disable Wi-Fi power-save (set after connect — the join can reset it).
+  // The default PM2 mode lets the AP buffer inbound frames until the radio
+  // wakes, adding tens of ms of asymmetric delay that biases the NTP-style
+  // clock offset and shows up as inter-controller beat skew. The LEDs dwarf
+  // the radio's power draw, so trade power for latency.
+  cyw43_wifi_pm(&cyw43_state, cyw43_pm_value(CYW43_NO_POWERSAVE_MODE, 20, 1, 1, 10));
   return 0;
 }
 
@@ -34,4 +40,6 @@ void hal_wifi_init() {
   cyw43_arch_enable_sta_mode();
 }
 
-void hal_wifi_deinit() { cyw43_arch_deinit(); }
+void hal_wifi_deinit() {
+  cyw43_arch_deinit();
+}

--- a/controller/src/hal/wifi/ports/pico_freertos/wifi.c
+++ b/controller/src/hal/wifi/ports/pico_freertos/wifi.c
@@ -3,12 +3,18 @@
 #include "hal/wifi.h"
 
 int wifi_connect(const char *wifi_ssid, const char *wifi_password) {
-  if (cyw43_arch_wifi_connect_blocking(wifi_ssid, wifi_password,
-                                       CYW43_AUTH_WPA2_AES_PSK)) {
+  if (cyw43_arch_wifi_connect_blocking(wifi_ssid, wifi_password, CYW43_AUTH_WPA2_AES_PSK)) {
     puts("[ERR] Failed to connect to WiFi");
     return 1;
   }
   printf("[NET] Connected to %s\n", wifi_ssid);
+
+  // Disable Wi-Fi power-save (set after connect — the join can reset it).
+  // The default PM2 mode lets the AP buffer inbound frames until the radio
+  // wakes, adding tens of ms of asymmetric delay that biases the NTP-style
+  // clock offset and shows up as inter-controller beat skew. The LEDs dwarf
+  // the radio's power draw, so trade power for latency.
+  cyw43_wifi_pm(&cyw43_state, cyw43_pm_value(CYW43_NO_POWERSAVE_MODE, 20, 1, 1, 10));
   return 0;
 }
 
@@ -30,4 +36,6 @@ void hal_wifi_init() {
   cyw43_arch_enable_sta_mode();
 }
 
-void hal_wifi_deinit() { cyw43_arch_deinit(); }
+void hal_wifi_deinit() {
+  cyw43_arch_deinit();
+}

--- a/controller/src/process/core1.c
+++ b/controller/src/process/core1.c
@@ -29,8 +29,12 @@ void core1_loop() {
       update_tempo(&ic_message);
     }
 
-    led_update();
-    sleep_ms(LED_CORE_SLEEP_MS);
+    uint32_t sleep_hint_us = led_update();
+    // Round up to the ms-granular HAL sleep; never spin (min 1 ms). The
+    // residual ≤1 ms overshoot past a beat boundary is far below the
+    // frame-interval quantization this replaces.
+    uint32_t sleep_duration_ms = (sleep_hint_us + 999u) / 1000u;
+    sleep_ms(sleep_duration_ms > 0 ? sleep_duration_ms : 1u);
     idx++;
   }
 }

--- a/controller/src/ws2812/include/ws2812/ws2812.h
+++ b/controller/src/ws2812/include/ws2812/ws2812.h
@@ -7,11 +7,15 @@
 
 void led_init();
 void led_set_random_pattern();
-void led_update();
+// Render one frame. Returns the suggested sleep before the next frame, in
+// microseconds: the regular frame interval, shortened when a beat boundary
+// falls inside it so the first frame of every beat lands on the boundary —
+// otherwise free-running render loops quantize beat onsets by up to a full
+// frame differently on every controller.
+uint32_t led_update(void);
 void update_tempo(intercore_message_t *ic_message);
 
-uint8_t calculate_beat_fraction(uint64_t current_time, uint64_t last_time,
-                                uint64_t next_time);
+uint8_t calculate_beat_fraction(uint64_t current_time, uint64_t last_time, uint64_t next_time);
 
 uint8_t scale8(uint64_t value, uint64_t range);
 

--- a/controller/src/ws2812/ws2812.c
+++ b/controller/src/ws2812/ws2812.c
@@ -171,7 +171,9 @@ void update_tempo(intercore_message_t *ic_message) {
   registry_unlock_mutex();
 }
 
-void led_update() {
+uint32_t led_update(void) {
+  const uint32_t frame_us = (uint32_t)LED_CORE_SLEEP_MS * 1000u;
+
   // Snapshot shared state under registry lock to prevent torn reads from core0
   registry_lock_mutex();
   uint64_t time_ref = _time_ref;
@@ -184,7 +186,7 @@ void led_update() {
   registry_unlock_mutex();
 
   if (time_ref == 0 || tempo_period_us == 0) {
-    return;
+    return frame_us;
   }
 
   static uint32_t colors[2][NUM_PIXELS];
@@ -246,4 +248,15 @@ void led_update() {
   _next_beat_time = next_beat_time;
   _next_beat_count = next_beat_count;
   registry_unlock_mutex();
+
+  // Wake for the beat boundary if it falls before the next regular frame so
+  // the onset frame renders right at the beat on every controller.
+  uint64_t after = time_us_64();
+  if (next_beat_time > after) {
+    uint64_t remaining = next_beat_time - after;
+    if (remaining < frame_us) {
+      return (uint32_t)remaining;
+    }
+  }
+  return frame_us;
 }

--- a/docs/api.markdown
+++ b/docs/api.markdown
@@ -321,8 +321,8 @@ Returns the list of connected Pico W devices.
 | `devices[].port_name` | string | Firmware port: `pico`, `pico-freertos`, `posix`, `posix-freertos`, `esp32`, or `unknown`. Empty for v2-or-older firmware. |
 | `devices[].git_sha` | string | Short Git SHA of the firmware build (possibly with `-dirty`). Empty for pre-v3 clients. |
 | `devices[].build_time_us` | number | Unix epoch microseconds of the firmware build. 0 for pre-v3 clients. |
-| `devices[].owd_us` | number | Server-smoothed one-way delay estimate (EWMA over the controller's reported `owd_us_estimate`). |
-| `devices[].qos` | object \| null | Protocol v4 diagnostic snapshot. `null` until the device has sent its first TEMPO_REQUEST or STATUS_RESPONSE. Fields: `current_offset_us`, `uptime_us`, `median_rtt_us`, `next_beat_gap_total`, `intercore_drop_total`, `time_sync_outlier_total`, `valid_sample_count`, `last_applied_program_seq`, `server_received_at_us`, `last_rtt_us`. |
+| `devices[].owd_us` | number | Server-smoothed one-way delay estimate (EWMA over the controller's reported `owd_us_estimate`). Diagnostic only — beat timestamps are not delay-compensated. |
+| `devices[].qos` | object \| null | Protocol v4 diagnostic snapshot. `null` until the device has sent its first TEMPO_REQUEST or STATUS_RESPONSE. Fields: `current_offset_us`, `uptime_us`, `median_rtt_us`, `next_beat_gap_total`, `intercore_drop_total`, `time_sync_outlier_total`, `valid_sample_count`, `last_applied_program_seq`, `server_received_at_us`, `last_rtt_us`, `sync_error_us` (server-side estimate of this device's clock-sync error: `current_offset_us - ((server_received_at_us - rtt/2) - uptime_us)`; `null` until an RTT sample exists). |
 | `count` | number | Total connected devices |
 
 ---
@@ -355,8 +355,8 @@ for the React Fleet QoS card and any external observability tooling.
 |-------|------|-------------|
 | `device_count` | number | Total registered controllers |
 | `reporting_count` | number | Number of controllers that have sent at least one v4 QoS snapshot |
-| `min_offset_us` / `max_offset_us` | number \| null | Lowest / highest reported controller-side server-time-offset |
-| `fleet_skew_us` | number \| null | `max_offset_us - min_offset_us`; the spread that drives the health pip |
+| `min_offset_us` / `max_offset_us` | number \| null | Lowest / highest reported controller-side server-time-offset. Raw diagnostic — dominated by each device's boot epoch, so not comparable across devices. |
+| `fleet_skew_us` | number \| null | Spread of per-device `sync_error_us` (`max - min`); approximates the worst-case beat skew across the fleet and drives the health pip. `null` until at least one device has a computable sync error. |
 | `min_rtt_us` / `mean_rtt_us` / `max_rtt_us` | number \| null | Aggregate over each controller's `median_rtt_us` |
 | `slowest_device_board_id` | string | board_id of the device whose `median_rtt_us` is the largest |
 | `total_next_beat_gap` | number | Sum of `next_beat_gap_total` across all reporting devices |

--- a/docs/controller-sync.markdown
+++ b/docs/controller-sync.markdown
@@ -31,7 +31,7 @@ sequenceDiagram
     Note over C: STATE: TEMPO_SYNCED
 
     loop Steady State (per beat, unicast by default)
-        S->>C: NEXT_BEAT (next_beat_ref - owd_us, count, seq)
+        S->>C: NEXT_BEAT (next_beat_ref, count, seq)
         Note over C: Schedule LED update at next_beat_ref<br/>track seq for loss detection
         S->>C: PROGRAM (program_id, seq) [on-change + 5Hz refresh]
     end
@@ -69,11 +69,11 @@ The median(RTT)/2 is also reported to the server as `owd_us_estimate` on the nex
 
 ### 3. Tempo Sync
 
-The controller sends a [TEMPO_REQUEST](protocol.html#tempo_request-3) carrying its current `owd_us_estimate`. The server replies with a [TEMPO_RESPONSE](protocol.html#tempo_response-4) containing the current beat reference time, beat period in microseconds, and active LED program ID. The server folds the reported OWD into a per-client EWMA (α=¼) that it uses to compensate broadcast timestamps — see step 4.
+The controller sends a [TEMPO_REQUEST](protocol.html#tempo_request-3) carrying its current `owd_us_estimate`. The server replies with a [TEMPO_RESPONSE](protocol.html#tempo_response-4) containing the current beat reference time, beat period in microseconds, and active LED program ID. The server folds the reported OWD into a per-client EWMA (α=¼) surfaced as `devices[].owd_us` — a diagnostic only. Beat timestamps are **not** delay-compensated: they travel in the synced-clock domain, where the NTP offset already absorbs path delay symmetrically, so subtracting OWD again would double-count it and skew controllers against each other by the difference of their estimates.
 
 ### 4. Steady State
 
-The server sends [NEXT_BEAT](protocol.html#next_beat-8) messages before each beat (unicast by default; see `--broadcast-mode` in [Deployment](deployment.html)) so the controller can pre-schedule its LED update. In unicast mode the embedded `next_beat_time_ref` is shifted by *this client's* `owd_us`, so heterogeneous Wi-Fi paths land their packets at the same intended hit instant.
+The server sends [NEXT_BEAT](protocol.html#next_beat-8) messages before each beat (unicast by default; see `--broadcast-mode` in [Deployment](deployment.html)) so the controller can pre-schedule its LED update. Every client receives the same `next_beat_time_ref`: it is interpreted through each controller's negotiated clock offset, so packet delivery timing doesn't move the beat — only clock-sync error does.
 
 [PROGRAM](protocol.html#program-7) is now pushed by the server **on state change** (instant fan-out via a StateManager callback) plus a 5 Hz refresh, so late joiners and missed broadcasts don't strand controllers on a wrong pattern. Each NEXT_BEAT and PROGRAM carries a 16-bit `seq` that the controller uses to count loss and reject stale duplicates.
 
@@ -85,7 +85,15 @@ Two complementary diagnostic channels feed `/api/devices.qos` and `/api/qos` so 
 
 **Server-initiated STATUS probe.** Every `--status-probe-ms` (default 5 s) the server unicasts a `STATUS_REQUEST` carrying its current wall time to every registered client. The controller echoes the timestamp on `STATUS_RESPONSE` and trails the same `beatled_qos_block_t`; the server stamps a fresh server-controlled RTT on receipt. The probe catches a "stale but online" controller without waiting for the next 10 s TEMPO heartbeat. Set `--status-probe-ms 0` to disable.
 
-`/api/qos` aggregates the latest snapshots: `fleet_skew_us = max_offset - min_offset` (a proxy for max controller-to-controller drift), mean / min / max RTT, slowest device, and totals of NEXT_BEAT gaps, intercore drops, and TIME-sync outliers. The server computes a `health` verdict (`ok` / `warn` / `fail`) from operator-tuned thresholds (`--qos-skew-warn-us`, `--qos-skew-fail-us`) so the React Fleet QoS card renders a single source of truth.
+`/api/qos` aggregates the latest snapshots: `fleet_skew_us` (the spread of per-device `sync_error_us` — see below), mean / min / max RTT, slowest device, and totals of NEXT_BEAT gaps, intercore drops, and TIME-sync outliers. The server computes a `health` verdict (`ok` / `warn` / `fail`) from operator-tuned thresholds (`--qos-skew-warn-us`, `--qos-skew-fail-us`) so the React Fleet QoS card renders a single source of truth.
+
+**Sync error.** A device's raw `current_offset_us` is dominated by its boot epoch (its clock starts at zero at power-on), so comparing raw offsets across devices measures who booted when, not sync quality. Instead the server forms its own view of each device's offset from a consistent timestamp pair — `uptime_us` (sampled when the controller builds the QoS block) and `server_received_at_us` (stamped on arrival), separated by one OWD (≈ RTT/2):
+
+```text
+sync_error_us = current_offset_us - ((server_received_at_us - rtt/2) - uptime_us)
+```
+
+Each device's `sync_error_us` (surfaced on `devices[].qos`) estimates how far its clock sync is off; `fleet_skew_us = max(sync_error) - min(sync_error)` approximates the real worst-case beat skew across the fleet.
 
 [BEAT](protocol.html#beat-9) is defined in the protocol catalogue for parity with the beat-detector callback but is not currently emitted by the live server. NEXT_BEAT is the steady-state timing channel.
 

--- a/server/src/core/include/core/client_status.hpp
+++ b/server/src/core/include/core/client_status.hpp
@@ -44,9 +44,10 @@ public:
   // requests; the broadcaster uses it for unicast delivery.
   asio::ip::udp::endpoint endpoint;
 
-  // Measured one-way delay (server→client) in microseconds, taken from the
-  // most recent TIME_REQUEST round-trip as RTT/2. 0 means no sample yet —
-  // the broadcaster should fall back to no compensation in that case.
+  // Measured one-way delay (server→client) in microseconds, reported by the
+  // controller as median(RTT)/2 on TEMPO_REQUEST. Diagnostic only: beat
+  // timestamps travel in the synced-clock domain, so delivery delay must
+  // NOT be compensated for (doing so double-counts the path delay).
   uint64_t owd_us = 0;
 
   // Firmware self-description carried on HELLO_REQUEST (protocol v3).
@@ -88,6 +89,27 @@ public:
   QosSnapshot latest_qos;
 };
 
+// Server-side estimate of a snapshot's clock-sync error, in microseconds.
+// The controller samples uptime_us when it builds the QoS block; the server
+// stamps server_received_at_us on arrival, one OWD (~RTT/2) later. So the
+// server's independent view of the controller's offset is
+//   (server_received_at_us - rtt/2) - uptime_us
+// and the difference from the controller's own current_offset_us is its
+// sync error. The spread of these errors across the fleet approximates the
+// real beat skew (each device's raw offset is dominated by its boot epoch
+// and is useless for cross-device comparison). Returns false when the
+// snapshot lacks the inputs (no probe seen yet / no RTT sample).
+inline bool qos_sync_error_us(const ClientStatus::QosSnapshot &q, int64_t &error_us) {
+  const uint32_t rtt = q.last_rtt_us > 0 ? q.last_rtt_us : q.median_rtt_us;
+  if (!q.valid || q.server_received_at_us == 0 || rtt == 0) {
+    return false;
+  }
+  const int64_t server_view =
+      static_cast<int64_t>(q.server_received_at_us - rtt / 2) - static_cast<int64_t>(q.uptime_us);
+  error_us = q.current_offset_us - server_view;
+  return true;
+}
+
 // Manually define to_json for ClientStatus to have full control over board_id serialization
 // board_id contains raw binary bytes from the Pico, so we convert to hex string
 inline void to_json(json &j, const ClientStatus &cs) {
@@ -123,6 +145,12 @@ inline void to_json(json &j, const ClientStatus &cs) {
         {"server_received_at_us", cs.latest_qos.server_received_at_us},
         {"last_rtt_us", cs.latest_qos.last_rtt_us},
     };
+    int64_t sync_error_us = 0;
+    if (qos_sync_error_us(cs.latest_qos, sync_error_us)) {
+      j["qos"]["sync_error_us"] = sync_error_us;
+    } else {
+      j["qos"]["sync_error_us"] = nullptr;
+    }
   } else {
     j["qos"] = nullptr;
   }

--- a/server/src/server/http/api_handler.cpp
+++ b/server/src/server/http/api_handler.cpp
@@ -393,6 +393,12 @@ APIHandler::req_status_t APIHandler::on_get_qos(const req_handle_t &req, route_p
   size_t reporting = 0;
   int64_t min_offset_us = std::numeric_limits<int64_t>::max();
   int64_t max_offset_us = std::numeric_limits<int64_t>::min();
+  // Fleet skew is the spread of per-device *sync errors* (see
+  // qos_sync_error_us): raw offsets are dominated by each device's boot
+  // epoch, so their spread measures who booted when, not sync quality.
+  size_t skew_reporting = 0;
+  int64_t min_sync_error_us = std::numeric_limits<int64_t>::max();
+  int64_t max_sync_error_us = std::numeric_limits<int64_t>::min();
   uint64_t min_rtt_us = std::numeric_limits<uint64_t>::max();
   uint64_t max_rtt_us = 0;
   uint64_t sum_rtt_us = 0;
@@ -410,6 +416,14 @@ APIHandler::req_status_t APIHandler::on_get_qos(const req_handle_t &req, route_p
       min_offset_us = qos.current_offset_us;
     if (qos.current_offset_us > max_offset_us)
       max_offset_us = qos.current_offset_us;
+    int64_t sync_error_us = 0;
+    if (core::qos_sync_error_us(qos, sync_error_us)) {
+      ++skew_reporting;
+      if (sync_error_us < min_sync_error_us)
+        min_sync_error_us = sync_error_us;
+      if (sync_error_us > max_sync_error_us)
+        max_sync_error_us = sync_error_us;
+    }
     if (qos.median_rtt_us > 0) {
       if (qos.median_rtt_us < min_rtt_us)
         min_rtt_us = qos.median_rtt_us;
@@ -438,7 +452,11 @@ APIHandler::req_status_t APIHandler::on_get_qos(const req_handle_t &req, route_p
   if (reporting > 0) {
     response["min_offset_us"] = min_offset_us;
     response["max_offset_us"] = max_offset_us;
-    response["fleet_skew_us"] = max_offset_us - min_offset_us;
+    if (skew_reporting > 0) {
+      response["fleet_skew_us"] = max_sync_error_us - min_sync_error_us;
+    } else {
+      response["fleet_skew_us"] = nullptr;
+    }
     response["mean_rtt_us"] = sum_rtt_us / reporting;
     response["min_rtt_us"] = min_rtt_us == std::numeric_limits<uint64_t>::max() ? 0 : min_rtt_us;
     response["max_rtt_us"] = max_rtt_us;
@@ -464,8 +482,9 @@ APIHandler::req_status_t APIHandler::on_get_qos(const req_handle_t &req, route_p
   // the fleet skew is fine.
   std::string health = "unknown";
   if (reporting > 0) {
-    const uint64_t skew_us =
-        (max_offset_us > min_offset_us) ? static_cast<uint64_t>(max_offset_us - min_offset_us) : 0;
+    const uint64_t skew_us = (skew_reporting > 0 && max_sync_error_us > min_sync_error_us)
+                                 ? static_cast<uint64_t>(max_sync_error_us - min_sync_error_us)
+                                 : 0;
     if (skew_us >= qos_thresholds_.skew_fail_us || total_intercore_drops > 0 ||
         total_time_sync_outliers > 0) {
       health = "fail";

--- a/server/src/server/tempo_broadcaster/include/tempo_broadcaster/tempo_broadcaster.hpp
+++ b/server/src/server/tempo_broadcaster/include/tempo_broadcaster/tempo_broadcaster.hpp
@@ -53,9 +53,10 @@ private:
   const char *SERVICE_NAME = "Tempo Broadcaster";
   const char *service_name() const override { return SERVICE_NAME; }
 
-  // Send a single buffer either as broadcast or as N unicast frames.
-  void dispatch(DataBuffer::Ptr response_buffer, bool compensate_owd,
-                uint64_t base_time_for_compensation);
+  // Send a single buffer either as broadcast or as N unicast frames. The
+  // same bytes go to every client: timestamps are in the shared synced-clock
+  // domain, so no per-recipient delivery compensation is needed (or correct).
+  void dispatch(DataBuffer::Ptr response_buffer);
 
   void send_to_endpoint(std::shared_ptr<DataBuffer> buffer,
                         const asio::ip::udp::endpoint &endpoint);

--- a/server/src/server/tempo_broadcaster/tempo_broadcaster.cpp
+++ b/server/src/server/tempo_broadcaster/tempo_broadcaster.cpp
@@ -70,7 +70,7 @@ void TempoBroadcaster::broadcast_next_beat(uint64_t next_beat_time_ref, uint32_t
     auto buffer = std::make_unique<NextBeatBuffer>(next_beat_time_ref, beat_count, seq);
     // Per-beat traffic — same reasoning as application.cpp.
     SPDLOG_DEBUG("{} next_beat seq={} t={} count={}", name(), seq, next_beat_time_ref, beat_count);
-    dispatch(std::move(buffer), /*compensate_owd=*/true, next_beat_time_ref);
+    dispatch(std::move(buffer));
   });
 }
 
@@ -83,7 +83,7 @@ void TempoBroadcaster::broadcast_beat(uint64_t beat_time_ref, uint32_t beat_coun
   asio::post(strand_, [this, beat_time_ref, beat_count]() {
     uint16_t seq = beat_seq_.fetch_add(1, std::memory_order_relaxed);
     auto buffer = std::make_unique<BeatBuffer>(beat_time_ref, beat_count, seq);
-    dispatch(std::move(buffer), /*compensate_owd=*/true, beat_time_ref);
+    dispatch(std::move(buffer));
   });
 }
 
@@ -97,8 +97,7 @@ void TempoBroadcaster::push_program_now() {
     SPDLOG_INFO("{} program push seq={} pid={}", name(), seq, pid);
 
     // Immediate send.
-    dispatch(std::make_unique<ProgramPushBuffer>(pid, seq),
-             /*compensate_owd=*/false, 0);
+    dispatch(std::make_unique<ProgramPushBuffer>(pid, seq));
 
     // Retry 50 ms later with the same seq so controllers that already
     // applied the first packet treat the retry as an idempotent no-op
@@ -113,8 +112,7 @@ void TempoBroadcaster::push_program_now() {
           if (ec || !is_running()) {
             return;
           }
-          dispatch(std::make_unique<ProgramPushBuffer>(pid, seq),
-                   /*compensate_owd=*/false, 0);
+          dispatch(std::make_unique<ProgramPushBuffer>(pid, seq));
         }));
   });
 }
@@ -137,57 +135,29 @@ void TempoBroadcaster::schedule_program_refresh() {
       }));
 }
 
-void TempoBroadcaster::dispatch(DataBuffer::Ptr response_buffer, bool compensate_owd,
-                                uint64_t base_time_for_compensation) {
+void TempoBroadcaster::dispatch(DataBuffer::Ptr response_buffer) {
+  // Timestamps in these messages live in the shared synced-clock domain:
+  // controllers convert them with the NTP-style offset they negotiated over
+  // TIME_REQUEST, which already accounts for path delay symmetrically. The
+  // per-client OWD rewrite this used to do on NEXT_BEAT/BEAT double-counted
+  // that delay and made each controller fire early by its own OWD — skewing
+  // controllers against each other by the *difference* of their estimates.
+  auto shared = std::shared_ptr<DataBuffer>(std::move(response_buffer));
+
   if (broadcasting_server_parameters_.mode != BroadcastMode::Unicast) {
-    // Broadcast mode: one packet, no per-client compensation possible.
-    auto shared = std::shared_ptr<DataBuffer>(std::move(response_buffer));
+    // Broadcast mode: one packet for everyone.
     send_to_endpoint(std::move(shared), broadcast_endpoint_);
     return;
   }
 
   // Unicast mode. Snapshot the client list (also prunes stale entries) and
-  // send one frame per registered client. For NEXT_BEAT/BEAT we rewrite the
-  // time field per-recipient to compensate measured one-way delay.
+  // send the same bytes to every registered client.
   auto clients = state_manager_.get_clients();
-  if (clients.empty()) {
-    return;
-  }
-
-  uint8_t type = response_buffer->type();
-  bool can_compensate =
-      compensate_owd && (type == BEATLED_MESSAGE_NEXT_BEAT || type == BEATLED_MESSAGE_BEAT);
-
   for (const auto &cs : clients) {
     if (cs->endpoint.port() == 0) {
       continue; // never observed a real endpoint
     }
-
-    if (!can_compensate || cs->owd_us == 0) {
-      // No per-client adjustment — share the same bytes.
-      auto shared = std::shared_ptr<DataBuffer>(new auto(*response_buffer));
-      send_to_endpoint(std::move(shared), cs->endpoint);
-      continue;
-    }
-
-    // Build a per-client copy with the time field shifted back by OWD so
-    // when the packet *arrives* at the controller, the embedded
-    // next_beat_time_ref equals the server's intended hit time.
-    uint64_t adjusted =
-        base_time_for_compensation > cs->owd_us ? base_time_for_compensation - cs->owd_us : 0;
-    DataBuffer::Ptr per_client;
-    if (type == BEATLED_MESSAGE_NEXT_BEAT) {
-      const auto *src =
-          reinterpret_cast<const beatled_message_next_beat_t *>(response_buffer->data().data());
-      per_client =
-          std::make_unique<NextBeatBuffer>(adjusted, ntohl(src->beat_count), ntohs(src->seq));
-    } else {
-      const auto *src =
-          reinterpret_cast<const beatled_message_beat_t *>(response_buffer->data().data());
-      per_client = std::make_unique<BeatBuffer>(adjusted, ntohl(src->beat_count), ntohs(src->seq));
-    }
-    auto shared = std::shared_ptr<DataBuffer>(std::move(per_client));
-    send_to_endpoint(std::move(shared), cs->endpoint);
+    send_to_endpoint(shared, cs->endpoint);
   }
 }
 


### PR DESCRIPTION
Diagnosis of two Pico W controllers visibly blinking out of sync surfaced four issues across the sync chain; one commit each.

## 1. Send identical NEXT_BEAT bytes to every controller (server)
The unicast path rewrote `next_beat_time_ref` per client as `intended_hit_time − owd_us`. Controllers interpret that field through the NTP-style clock offset negotiated over TIME_REQUEST, which already absorbs path delay symmetrically — so the rewrite double-counted the delay, making each controller fire early by its own OWD estimate and skewing controllers against each other by the **difference** of their estimates (tens of ms on heterogeneous Wi-Fi paths). Dispatch now shares one buffer across all recipients.

## 2. Disable Wi-Fi power-save on the Pico W ports (controller)
The CYW43 default PM2 mode buffers inbound frames at the AP until the radio wakes, adding tens of ms of **asymmetric** delay. The offset formula assumes symmetry; the median filter rejects spikes but not a consistent bias, so each Pico's clock offset was biased differently. Power-save is now disabled after connect on both `pico` and `pico_freertos` ports.

## 3. Wake the LED loop on beat boundaries (controller)
The render loop free-ran at 10 ms, unaligned across devices, quantizing beat onsets up to a full frame apart even with perfect sync. `led_update` now returns a sleep hint that shortens the final sleep before a beat boundary, so the onset frame lands on the boundary (±1 ms) on every controller.

## 4. Measure fleet skew as clock-sync disagreement (server + docs)
`fleet_skew_us` was max−min of raw `current_offset_us`, which is dominated by each device's boot epoch — it measured who booted when, not sync quality. The server now computes a per-device `sync_error_us` from the stored `(uptime_us, server_received_at_us, rtt)` triple and reports the spread of those errors; the health pip keys off the new value. Response field names unchanged; `devices[].qos.sync_error_us` is additive.

## Verification
- All server tests pass; all 8 POSIX firmware Catch2 binaries pass.
- `pico` and `pico-freertos` UF2 cross-builds clean.
- Hardware check: flash both Picos, run a strobe-like pattern, film in slo-mo — the constant lead/lag should collapse; `GET /api/qos` `fleet_skew_us` should now read in the low single-digit ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)