### PR TITLE
Build PortAudio with the ALSA backend for the RPi server

### DIFF
--- a/server/cmake/arm64-linux-custom.cmake
+++ b/server/cmake/arm64-linux-custom.cmake
@@ -1,7 +1,3 @@
-variable_watch(ALSA_LIBRARIES)
-variable_watch(PA_USE_ALSA)
-variable_watch(PA_ALSA_DYNAMIC)
-
 # set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_TARGET_ARCHITECTURE aarch64-linux-gnu)
 set(VCPKG_CRT_LINKAGE dynamic)
@@ -14,6 +10,16 @@ set(VCPKG_C_FLAGS -DNO_RECVMMSG)
 if(${PORT} MATCHES "portaudio")
     # set(VCPKG_LIBRARY_LINKAGE dynamic)
     set(PA_ALSA_DYNAMIC ON)
+    # vcpkg restricts find_package() to its own tree, so PortAudio's
+    # find_package(ALSA) misses the apt-installed system libasound and
+    # silently ships a JACK-only build (0 host APIs on the Pi). This is a
+    # native arm64 container build, so point FindALSA straight at the
+    # system aarch64 libasound (libasound2-dev). With PA_ALSA_DYNAMIC the
+    # lib is dlopen'd at runtime; we only need the headers + .so to build.
+    set(VCPKG_CMAKE_CONFIGURE_OPTIONS
+        "-DPA_USE_ALSA=ON"
+        "-DALSA_INCLUDE_DIR=/usr/include"
+        "-DALSA_LIBRARY=/usr/lib/aarch64-linux-gnu/libasound.so")
 endif()
 
 


### PR DESCRIPTION
## Problem

The deployed `beat_server` found no audio input on the Pi:

```
audio_input.cpp:23  Host APIs available: 0
audio_input.cpp:37  PortAudio device count: 0
audio_input.cpp:41  Error: No default input device.
```

The beat detector died on start — even though the USB mic is healthy (ALSA sees it as `card 3: USB PnP Sound Device`).

## Cause

vcpkg's `portaudio` pulls in `jack2` but expects **ALSA** from the system, and vcpkg restricts `find_package()` to its own installed tree. So PortAudio's `find_package(ALSA)` never saw the apt-installed `libasound2-dev:arm64` and shipped a **JACK-only** build — and with no `jackd` on the Pi, that's zero host APIs. (The binary linked `libjack.so.0` and not `libasound`.) A prior author had left `variable_watch()` probes in the triplet for exactly this problem; removed here.

## Fix

The RPi image builds as a **native arm64** container (Docker on Apple Silicon), so point `FindALSA` straight at the system aarch64 `libasound` for the `portaudio` port, in `server/cmake/arm64-linux-custom.cmake`:

```cmake
set(VCPKG_CMAKE_CONFIGURE_OPTIONS
    "-DPA_USE_ALSA=ON"
    "-DALSA_INCLUDE_DIR=/usr/include"
    "-DALSA_LIBRARY=/usr/lib/aarch64-linux-gnu/libasound.so")
```

`PA_ALSA_DYNAMIC` (already set) means libasound is `dlopen`'d at runtime, so only headers + `.so` are needed at build time. The ALSA host API (`pa_linux_alsa.c`) is now compiled into the binary.

## Verified (after rebuild + redeploy)

```
Host APIs available: 1
PortAudio device count: 6
AlsaOpen: Opening device hw:3,0        ← the USB mic
Stream info: input latency 0.0116, sample rate 44100
beat_detector_impl.h: Beat: ... / Next beat: ...   ← detecting beats
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)