### PR TITLE
Add avahi-alias service to publish an extra mDNS name

### DIFF
--- a/docs/cli.markdown
+++ b/docs/cli.markdown
@@ -202,6 +202,15 @@ network. The upstream networks are activated by NetworkManager profile
 name, so a profile must already exist whose name matches each SSID —
 create them once with `nmcli dev wifi connect "<SSID>"`.
 
+`install-service.sh` also installs an `avahi-alias` unit, which publishes an
+extra mDNS name (`MDNS_ALIAS`, default `beatled.local`) via
+`avahi-publish -a -R`, so the Pi answers to that name *in addition to*
+`<hostname>.local`. The `-R` (no reverse PTR) is required: the host's
+primary name already owns the address's PTR, so publishing another would
+collide. Generate the server certificate with both names
+(`./beatled.sh certs beatled.local raspberrypi.local`) so HTTPS validates
+under either.
+
 ## `test`, `build`, `clean`
 
 ```sh

--- a/scripts/deploy/avahi-alias.sh
+++ b/scripts/deploy/avahi-alias.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Publish an extra mDNS .local name for this host so it answers to more
+# than just <hostname>.local. Runs in the foreground (avahi-publish holds
+# the registration for as long as it lives), so the systemd unit uses
+# Type=simple with Restart=always.
+#
+# usage: avahi-alias.sh <alias.local>
+#
+set -uo pipefail
+
+ALIAS="${1:?usage: avahi-alias.sh <alias.local>}"
+
+# avahi-publish -a registers an A record, so it needs the current IP. Take
+# the first non-loopback address (wlan0 / eth0). If the lease changes, the
+# unit is restarted (Restart=always) and re-resolves.
+IP="$(hostname -I | awk '{print $1}')"
+if [[ -z "$IP" ]]; then
+  echo "avahi-alias: no IP address yet for $ALIAS" >&2
+  exit 1
+fi
+
+# -R / --no-reverse: don't publish a reverse PTR for the address. The
+# host's primary name (<hostname>.local) already owns the PTR for this IP,
+# so publishing another would collide ("Local name collision"). We only
+# need the forward name -> address record for the alias.
+echo "Publishing mDNS alias $ALIAS -> $IP"
+exec avahi-publish -a -R "$ALIAS" "$IP"

--- a/scripts/deploy/avahi-alias.template.service
+++ b/scripts/deploy/avahi-alias.template.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Publish an extra mDNS .local alias for this host
+After=network-online.target avahi-daemon.service
+Wants=network-online.target
+Requires=avahi-daemon.service
+
+[Service]
+Type=simple
+ExecStart=$ROOT_DIR/scripts/deploy/avahi-alias.sh "${MDNS_ALIAS}"
+Restart=always
+RestartSec=5
+User=${USERNAME}
+Group=${USERNAME}
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$ROOT_DIR
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/deploy/install-service.sh
+++ b/scripts/deploy/install-service.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 #
-# Install the beat-server and wifi-fallback systemd services on a
-# Raspberry Pi. Each service file is generated from its template
+# Install the beat-server, wifi-fallback, and avahi-alias systemd services
+# on a Raspberry Pi. Each service file is generated from its template
 # (envsubst) and then enabled and started.
+#
+# The avahi-alias service publishes an extra mDNS name so the Pi answers to
+# <MDNS_ALIAS> in addition to <hostname>.local. Override the name via the
+# environment (or controller/.env.wifi): MDNS_ALIAS (default beatled.local).
 #
 # The wifi-fallback service brings up known NetworkManager connections on
 # boot — the WiFi networks defined once in controller/.env.wifi, tried in
@@ -48,8 +52,9 @@ if [[ -f "$WIFI_ENV" ]]; then
   # shellcheck disable=SC1090
   source "$WIFI_ENV"
 fi
-# Default only applies if neither the environment nor .env.wifi set it.
+# Defaults only apply if neither the environment nor .env.wifi set them.
 export HOTSPOT_CON="${HOTSPOT_CON:-beatled-hotspot}"
+export MDNS_ALIAS="${MDNS_ALIAS:-beatled.local}"
 : "${WIFI_SSID:=}"
 : "${WIFI_SSID_2:=}"
 : "${WIFI_SSID_3:=}"
@@ -98,10 +103,13 @@ install_service() {
   fi
 }
 
-info "Installing services (ROOT_DIR=$ROOT_DIR, networks=[${WIFI_CONNECTIONS:-none}], HOTSPOT_CON=$HOTSPOT_CON)"
+info "Installing services (ROOT_DIR=$ROOT_DIR, networks=[${WIFI_CONNECTIONS:-none}], HOTSPOT_CON=$HOTSPOT_CON, MDNS_ALIAS=$MDNS_ALIAS)"
 
-# wifi-fallback.sh is executed by the service; make sure it's runnable.
-chmod +x "$SCRIPT_DIR/wifi-fallback.sh"
+# These are executed by their services; make sure they're runnable.
+chmod +x "$SCRIPT_DIR/wifi-fallback.sh" "$SCRIPT_DIR/avahi-alias.sh"
 
 install_service beat-server
 install_service wifi-fallback enable
+# Publishing an mDNS record doesn't touch the network link, so it's safe to
+# start now (unlike wifi-fallback, which would bounce the deploy's WiFi).
+install_service avahi-alias


### PR DESCRIPTION
## What

Installs an `avahi-alias` systemd unit (alongside `wifi-fallback`) so the Raspberry Pi answers to an extra mDNS name — `MDNS_ALIAS`, default `beatled.local` — **in addition to** `<hostname>.local` (`raspberrypi.local`). Both names stay live.

## Why

We wanted `beatled.local` to reach the Pi without dropping `raspberrypi.local`. mDNS only publishes one hostname per host, so the alias is published as a separate record via `avahi-publish`.

## Notes

- **`-R` / `--no-reverse` is required.** Publishing the alias to the host's own IP otherwise fails with *"Local name collision"*, because the primary name already owns the reverse PTR for that address. We only need the forward name→IP record.
- **Started live during deploy.** Unlike `wifi-fallback` (which re-activates the WiFi link and would drop a deploy running over that link, so it's enable-only), publishing an mDNS record is link-neutral — so `beatled.local` works immediately, no reboot.
- `MDNS_ALIAS` is overridable via env or `controller/.env.wifi`, mirroring `HOTSPOT_CON`.
- Generate the server cert with both names so HTTPS validates under either: `./beatled.sh certs beatled.local raspberrypi.local`.

## Verified on the Pi

- `avahi-alias.service` active + enabled; `beatled.local` resolves to the Pi on the LAN.
- `https://beatled.local:8443/api/health` and `https://raspberrypi.local:8443/api/health` both return `{"status":"ok"}`.
- Cert SANs now include `beatled.local` + `raspberrypi.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)