### PR TITLE
AP-mode control: POST /api/ap + React/iOS clients

### DIFF
--- a/client/src/lib/__tests__/ap.test.ts
+++ b/client/src/lib/__tests__/ap.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { apControl } from "../ap";
+
+// Mock only the fetch helpers; the error-classification helpers stay real.
+vi.mock("../api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api")>()),
+  getEndpoint: vi.fn(),
+  postEndpoint: vi.fn(),
+}));
+
+import { postEndpoint, ApiError } from "../api";
+
+describe("apControl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("queries status and parses the ap field", async () => {
+    (postEndpoint as Mock).mockResolvedValue({
+      json: () => Promise.resolve({ ap: "off" }),
+    });
+
+    const result = await apControl("status");
+
+    expect(postEndpoint).toHaveBeenCalledWith("/api/ap", { mode: "status" });
+    expect(result.ap).toBe("off");
+  });
+
+  it("includes revertMinutes when turning the hotspot on", async () => {
+    (postEndpoint as Mock).mockResolvedValue({
+      json: () => Promise.resolve({ result: "ok", mode: "on" }),
+    });
+
+    await apControl("on", 10);
+
+    expect(postEndpoint).toHaveBeenCalledWith("/api/ap", { mode: "on", revertMinutes: 10 });
+  });
+
+  it("omits revertMinutes when zero", async () => {
+    (postEndpoint as Mock).mockResolvedValue({
+      json: () => Promise.resolve({ result: "ok", mode: "on" }),
+    });
+
+    await apControl("on", 0);
+
+    expect(postEndpoint).toHaveBeenCalledWith("/api/ap", { mode: "on" });
+  });
+
+  it("maps a network error to a failure response", async () => {
+    (postEndpoint as Mock).mockRejectedValue(new ApiError("network"));
+
+    const result = await apControl("off");
+
+    expect(result.error).toBe(true);
+    expect(typeof result.status).toBe("string");
+  });
+});

--- a/client/src/lib/ap.ts
+++ b/client/src/lib/ap.ts
@@ -1,0 +1,47 @@
+import { postEndpoint, toApiFailure, invalidResponse, type ApiErrorKind } from "./api";
+
+export type ApMode = "on" | "off" | "status";
+
+// Response from POST /api/ap. A "status" query returns `ap`; "on"/"off"
+// actions return `result`/`mode`/`output`. Failures carry `error` + `status`
+// (the human-readable message the views render), mirroring the other helpers.
+export interface ApResponse {
+  error?: boolean;
+  kind?: ApiErrorKind;
+  httpStatus?: number;
+  ap?: "on" | "off";
+  result?: string;
+  mode?: string;
+  output?: string;
+  status?: string;
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export function isApResponse(v: unknown): v is ApResponse {
+  if (!isRecord(v)) return false;
+  if (v.ap !== undefined && v.ap !== "on" && v.ap !== "off") return false;
+  return true;
+}
+
+// Toggle the Pi's WiFi between client and access-point mode, or query it.
+// `revertMinutes` only applies to "on": the Pi switches back to WiFi after
+// that long (a safety net so a bad switch can't strand it). Note that "on"
+// tears down the link this request travels over, so the call usually fails
+// to return even though the switch succeeds — callers should treat a
+// network error after an "on" as "probably switched, reconnect on the AP".
+export async function apControl(mode: ApMode, revertMinutes?: number): Promise<ApResponse> {
+  try {
+    const body: { mode: ApMode; revertMinutes?: number } = { mode };
+    if (mode === "on" && revertMinutes && revertMinutes > 0) {
+      body.revertMinutes = revertMinutes;
+    }
+    const res = await postEndpoint("/api/ap", body);
+    const json: unknown = await res.json();
+    return isApResponse(json) ? json : invalidResponse();
+  } catch (err) {
+    return toApiFailure(err);
+  }
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -61,7 +61,8 @@ export type ApiEndpoint =
   | "/api/health"
   | "/api/log"
   | "/api/service/control"
-  | "/api/tempo/manual";
+  | "/api/tempo/manual"
+  | "/api/ap";
 
 export type ApiErrorKind = "http" | "network" | "timeout" | "invalid";
 

--- a/client/src/views/config.tsx
+++ b/client/src/views/config.tsx
@@ -5,6 +5,7 @@ import PageHeader from "../components/page-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
 import {
   getAPIHost,
   setAPIHost,
@@ -12,6 +13,7 @@ import {
   setAPIToken,
   pingHealth,
 } from "../lib/api";
+import { apControl } from "../lib/ap";
 import { useInterval } from "../hooks/interval";
 
 export async function loader() {
@@ -99,6 +101,99 @@ function useHealthChecks() {
   return statuses;
 }
 
+function AccessPointCard() {
+  const [apStatus, setApStatus] = useState<"on" | "off" | "unknown">("unknown");
+  const [revertMinutes, setRevertMinutes] = useState(10);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await apControl("status");
+    setApStatus(res.error ? "unknown" : (res.ap ?? "unknown"));
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const switchOn = async () => {
+    const revertNote =
+      revertMinutes > 0 ? ` It will auto-revert to WiFi after ${revertMinutes} min.` : "";
+    if (
+      !window.confirm(
+        `Switch the Pi to hotspot mode? This device will lose its connection to the server.${revertNote}\n\n` +
+          `Rejoin the "Beatled" WiFi network, then open https://192.168.4.1:8443/ to continue.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    setMessage(
+      'Switching to hotspot — this device will lose connection. Rejoin the "Beatled" WiFi and open https://192.168.4.1:8443/.',
+    );
+    // The response usually never returns (the Pi's radio switches mid-request),
+    // so we don't depend on it; the message above stays up.
+    await apControl("on", revertMinutes);
+    setBusy(false);
+  };
+
+  const switchOff = async () => {
+    setBusy(true);
+    setMessage(null);
+    const res = await apControl("off");
+    setBusy(false);
+    if (res.error) {
+      setMessage(`Failed to switch to WiFi: ${res.status ?? "error"}`);
+    } else {
+      await refresh();
+    }
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">Access Point</Label>
+          <span className="text-sm text-muted-foreground">
+            Hotspot is {apStatus === "unknown" ? "—" : apStatus}
+          </span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Switch the Raspberry Pi between your WiFi and its own “Beatled” hotspot
+          (192.168.4.1). The Pi has a single radio, so turning the hotspot on drops
+          this connection — rejoin the “Beatled” network to reconnect.
+        </p>
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="flex flex-col gap-1">
+            <Label
+              htmlFor="ap-revert"
+              className="text-xs font-normal text-muted-foreground"
+            >
+              Auto-revert (min)
+            </Label>
+            <input
+              id="ap-revert"
+              type="number"
+              min={0}
+              max={1440}
+              value={revertMinutes}
+              onChange={(e) => setRevertMinutes(Number(e.target.value))}
+              className="flex h-9 w-24 rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            />
+          </div>
+          <Button variant="outline" disabled={busy} onClick={switchOn}>
+            Switch to Hotspot
+          </Button>
+          <Button variant="secondary" disabled={busy} onClick={switchOff}>
+            Switch to WiFi
+          </Button>
+        </div>
+        {message && <p className="text-xs text-amber-600">{message}</p>}
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function ConfigPage() {
   const submit = useSubmit();
   const { host, token } = useLoaderData() as { host: string; token: string };
@@ -173,6 +268,7 @@ export default function ConfigPage() {
             />
           </CardContent>
         </Card>
+        <AccessPointCard />
       </div>
     </>
   );

--- a/docs/api.markdown
+++ b/docs/api.markdown
@@ -15,6 +15,7 @@ REST API served over HTTPS on port **8443**. Used by the React, iOS, and macOS c
 | `/api/health`          | GET      | Lightweight health check (no auth required)       |
 | `/api/status`          | GET      | Service status, tempo, client list                |
 | `/api/service/control` | POST     | Start/stop services                               |
+| `/api/ap`              | POST     | Switch WiFi between client and access-point mode   |
 | `/api/tempo`           | GET      | Current tempo and time reference                  |
 | `/api/tempo/manual`    | POST     | Set the manual (operator-chosen) BPM              |
 | `/api/program`         | GET/POST | Get/set LED program                               |
@@ -132,6 +133,65 @@ Start or stop a server service.
 |--------|-----------|
 | `400 Bad Request` | Missing `id` or `status` field, body too large, or invalid JSON |
 | `404 Not Found` | Service ID not recognized |
+| `429 Too Many Requests` | Rate limit exceeded |
+
+---
+
+### POST /api/ap
+
+Switch the Raspberry Pi's WiFi between client mode and access-point (hotspot)
+mode by shelling out to `scripts/deploy/ap-mode.sh`. Only meaningful on the Pi
+deployment (it drives NetworkManager via the `network-control` polkit grant the
+deploy installs).
+
+**The Pi has a single radio, so AP and client modes are mutually exclusive.**
+Switching to AP mode tears down the WiFi link this request arrived over — the
+client must rejoin the `Beatled` hotspot and reconnect at `https://192.168.4.1:8443/`
+to see anything further. The server itself keeps running.
+
+**Request body**
+
+```json
+{
+  "mode": "on",
+  "revertMinutes": 10
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mode` | string | Yes | `on` (activate hotspot), `off` (reconnect to WiFi), or `status` |
+| `revertMinutes` | integer | No | Only with `mode: "on"`. Auto-switch back to WiFi after N minutes (1–1440). A safety net so a bad switch can't strand a headless Pi. Omit or `0` to stay on AP until switched back. |
+
+**Response** `200 OK`
+
+For `status`:
+
+```json
+{
+  "ap": "on"
+}
+```
+
+For `on` / `off`:
+
+```json
+{
+  "result": "ok",
+  "mode": "on",
+  "output": "Auto-revert to WiFi scheduled in 10 min.\nActivating AP 'beatled-hotspot' (this drops upstream WiFi)..."
+}
+```
+
+> Note: when `mode` is `on`, the response may never reach the caller because the
+> radio switches mid-request. The action still completes on the Pi.
+
+**Error responses**
+
+| Status | Condition |
+|--------|-----------|
+| `400 Bad Request` | Missing/invalid `mode`, `revertMinutes` out of range, body too large, or invalid JSON |
+| `500 Internal Server Error` | `ap-mode.sh` exited non-zero (response includes `exitCode` and `output`) |
 | `429 Too Many Requests` | Rate limit exceeded |
 
 ---

--- a/ios/Beatled.xcodeproj/project.pbxproj
+++ b/ios/Beatled.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		13D6FB26AEA788BC294BD3A3 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F749EE3E74AECEB31026F1D /* ContentView.swift */; };
 		1418267305D97C73FB25E29E /* LogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BF06DDE0B6B8803F5B42F1 /* LogView.swift */; };
 		17AA8488ED21DA995E4004AD /* StatusResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9106995968A0316F9F31622 /* StatusResponse.swift */; };
+		18197B2C91F45C27D0F281FE /* APControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 635108130F23CEBC1900FEE6 /* APControl.swift */; };
 		19114D2608E0F74A3376F83E /* ModelDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8754137130FC478D75E82EF6 /* ModelDecodingTests.swift */; };
 		1AE3A9C872DF2DB0053C50D7 /* StatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1354C68D97A0EDB225AFE1 /* StatusViewModel.swift */; };
 		22A439037DA2BFBEEA8CEAD9 /* DevicesTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 751F82AA9019C576A3CA4DCC /* DevicesTableView.swift */; };
@@ -55,6 +56,7 @@
 		55E57C1A3245EEAE87CF9636 /* BeatledApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BeatledApp.swift; sourceTree = "<group>"; };
 		5CB1CF167EDC1703B1BD416A /* LogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewModel.swift; sourceTree = "<group>"; };
 		5FE8D2C5E265ECEE76B4B0ED /* ConfigView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigView.swift; sourceTree = "<group>"; };
+		635108130F23CEBC1900FEE6 /* APControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APControl.swift; sourceTree = "<group>"; };
 		751F82AA9019C576A3CA4DCC /* DevicesTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesTableView.swift; sourceTree = "<group>"; };
 		76A9BB2113721CF86270068E /* MacContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacContentView.swift; sourceTree = "<group>"; };
 		83299CC20BCCD48CD6362F2F /* ProgramView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramView.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 		595181B027B207774EC300C7 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				635108130F23CEBC1900FEE6 /* APControl.swift */,
 				83FC5634E6FA65CF4627004E /* ProgramResponse.swift */,
 				B6D076B1289D1C9656679428 /* ServiceControl.swift */,
 				A9106995968A0316F9F31622 /* StatusResponse.swift */,
@@ -255,6 +258,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				18197B2C91F45C27D0F281FE /* APControl.swift in Sources */,
 				AF4D496681165E601BAC855E /* APIClient.swift in Sources */,
 				FC8410980F9E9F46F664CFC3 /* AppSettings.swift in Sources */,
 				C9CB8BAF3914F5268CD933C5 /* BeatledApp.swift in Sources */,

--- a/ios/Beatled/BeatledApp.swift
+++ b/ios/Beatled/BeatledApp.swift
@@ -11,7 +11,7 @@ struct BeatledApp: App {
         let client = APIClient(settings: settings)
         self._settings = State(initialValue: settings)
         self._apiClient = State(initialValue: client)
-        self._configViewModel = State(initialValue: ConfigViewModel(settings: settings))
+        self._configViewModel = State(initialValue: ConfigViewModel(settings: settings, api: client))
     }
 
     var body: some Scene {

--- a/ios/Beatled/Models/APControl.swift
+++ b/ios/Beatled/Models/APControl.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// POST /api/ap — switch the Pi's WiFi between client and access-point mode.
+// `revertMinutes` only applies to mode "on" (auto-switch back after N minutes);
+// it's optional, so the synthesized encoder omits it when nil.
+struct APControlRequest: Encodable {
+    let mode: String
+    let revertMinutes: Int?
+}
+
+// Response to a "status" query.
+struct APStatusResponse: Decodable {
+    let ap: String // "on" or "off"
+}
+
+// Response to an "on"/"off" action.
+struct APActionResponse: Decodable {
+    let result: String
+    let mode: String
+    let output: String
+}

--- a/ios/Beatled/ViewModels/ConfigViewModel.swift
+++ b/ios/Beatled/ViewModels/ConfigViewModel.swift
@@ -44,6 +44,14 @@ class ConfigViewModel {
     var settings: AppSettings
     var healthStatuses: [HostPreset: HealthStatus] = [:]
 
+    // Access-point (hotspot) control via POST /api/ap.
+    var apStatus: String = "unknown" // "on", "off", or "unknown"
+    var apMessage: String?
+    var apBusy = false
+    var revertMinutes: Int = 10
+
+    private let api: APIClient
+
     var selectedPreset: HostPreset {
         didSet {
             if selectedPreset == .custom {
@@ -62,8 +70,9 @@ class ConfigViewModel {
         }
     }
 
-    init(settings: AppSettings) {
+    init(settings: AppSettings, api: APIClient) {
         self.settings = settings
+        self.api = api
         self.selectedPreset = HostPreset.from(host: settings.apiHost)
         if self.selectedPreset == .custom {
             self.customHost = settings.apiHost
@@ -134,6 +143,51 @@ class ConfigViewModel {
             for await (preset, status) in group {
                 healthStatuses[preset] = status
             }
+        }
+    }
+
+    // MARK: - Access point control
+
+    @MainActor
+    func refreshAPStatus() async {
+        do {
+            let resp: APStatusResponse = try await api.post(
+                "/api/ap", body: APControlRequest(mode: "status", revertMinutes: nil))
+            apStatus = resp.ap
+        } catch {
+            apStatus = "unknown"
+        }
+    }
+
+    /// Switch the Pi to hotspot mode. The single radio means this tears down
+    /// the link this request travels over, so the response usually never
+    /// arrives — we don't depend on it and leave the guidance message up.
+    @MainActor
+    func switchAPOn() {
+        apBusy = true
+        apMessage = "Switching to hotspot — this device will lose connection. "
+            + "Rejoin the \"Beatled\" WiFi and open https://192.168.4.1:8443/."
+        Task { @MainActor in
+            let mins = revertMinutes > 0 ? revertMinutes : nil
+            let _: APActionResponse? = try? await api.post(
+                "/api/ap", body: APControlRequest(mode: "on", revertMinutes: mins))
+            apBusy = false
+        }
+    }
+
+    @MainActor
+    func switchAPOff() {
+        apBusy = true
+        apMessage = nil
+        Task { @MainActor in
+            do {
+                let _: APActionResponse = try await api.post(
+                    "/api/ap", body: APControlRequest(mode: "off", revertMinutes: nil))
+                await refreshAPStatus()
+            } catch {
+                apMessage = "Failed to switch to WiFi: \(error.localizedDescription)"
+            }
+            apBusy = false
         }
     }
 }

--- a/ios/Beatled/Views/ConfigView.swift
+++ b/ios/Beatled/Views/ConfigView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ConfigView: View {
     @State var viewModel: ConfigViewModel
     @State private var showInsecureWarning = false
+    @State private var showAPWarning = false
 
     var body: some View {
         NavigationStack {
@@ -10,6 +11,7 @@ struct ConfigView: View {
                 serverSection
                 authenticationSection
                 securitySection
+                accessPointSection
                 aboutSection
             }
             .formStyle(.grouped)
@@ -24,7 +26,43 @@ struct ConfigView: View {
             } message: {
                 Text("Allowing insecure connections bypasses certificate validation and may expose your data to security risks. Only enable this for development or when connecting to trusted servers with self-signed certificates.")
             }
+            .alert("Switch to Hotspot?", isPresented: $showAPWarning) {
+                Button("Cancel", role: .cancel) {}
+                Button("Switch", role: .destructive) { viewModel.switchAPOn() }
+            } message: {
+                Text(
+                    "This device will lose its connection to the server. Rejoin the “Beatled” WiFi and open https://192.168.4.1:8443/ to continue."
+                    + (viewModel.revertMinutes > 0
+                       ? " The Pi auto-reverts to WiFi after \(viewModel.revertMinutes) min."
+                       : ""))
+            }
         }
+    }
+
+    @ViewBuilder
+    private var accessPointSection: some View {
+        Section {
+            LabeledContent("Hotspot") {
+                Text(viewModel.apStatus == "unknown" ? "—" : viewModel.apStatus)
+                    .foregroundStyle(.secondary)
+            }
+            Stepper("Auto-revert: \(viewModel.revertMinutes) min",
+                    value: $viewModel.revertMinutes, in: 0...1440)
+            Button("Switch to Hotspot") { showAPWarning = true }
+                .disabled(viewModel.apBusy)
+            Button("Switch to WiFi") { viewModel.switchAPOff() }
+                .disabled(viewModel.apBusy)
+            if let message = viewModel.apMessage {
+                Label(message, systemImage: "wifi.exclamationmark")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        } header: {
+            Text("Access Point")
+        } footer: {
+            Text("Switch the Pi between your WiFi and its own “Beatled” hotspot (192.168.4.1). The Pi has a single radio, so turning the hotspot on drops this connection — rejoin the “Beatled” network to reconnect.")
+        }
+        .task { await viewModel.refreshAPStatus() }
     }
 
     @ViewBuilder

--- a/ios/BeatledTests/ConfigViewModelTests.swift
+++ b/ios/BeatledTests/ConfigViewModelTests.swift
@@ -48,20 +48,22 @@ final class ConfigViewModelTests: XCTestCase {
     // MARK: ConfigViewModel
 
     func testInitSelectsMatchingPreset() {
-        let viewModel = ConfigViewModel(settings: makeSettings(host: "https://beatled.local:8443"))
+        let viewModel = ConfigViewModel(settings: makeSettings(host: "https://beatled.local:8443"),
+                                        api: APIClient(settings: makeSettings()))
         XCTAssertEqual(viewModel.selectedPreset, .beatledLocal)
         XCTAssertEqual(viewModel.customHost, "")
     }
 
     func testInitWithUnknownHostSelectsCustomAndKeepsHost() {
-        let viewModel = ConfigViewModel(settings: makeSettings(host: "https://example.com:9999"))
+        let viewModel = ConfigViewModel(settings: makeSettings(host: "https://example.com:9999"),
+                                        api: APIClient(settings: makeSettings()))
         XCTAssertEqual(viewModel.selectedPreset, .custom)
         XCTAssertEqual(viewModel.customHost, "https://example.com:9999")
     }
 
     func testSelectingPresetWritesHostToSettings() {
         let settings = makeSettings()
-        let viewModel = ConfigViewModel(settings: settings)
+        let viewModel = ConfigViewModel(settings: settings, api: APIClient(settings: settings))
 
         viewModel.selectedPreset = .raspberryPi
 
@@ -71,7 +73,7 @@ final class ConfigViewModelTests: XCTestCase {
 
     func testCustomHostWritesThroughOnlyWhenCustomSelected() {
         let settings = makeSettings(host: "https://example.com:9999")
-        let viewModel = ConfigViewModel(settings: settings)
+        let viewModel = ConfigViewModel(settings: settings, api: APIClient(settings: settings))
 
         viewModel.customHost = "https://other.example:1234"
         XCTAssertEqual(settings.apiHost, "https://other.example:1234")

--- a/ios/BeatledTests/ModelDecodingTests.swift
+++ b/ios/BeatledTests/ModelDecodingTests.swift
@@ -238,4 +238,38 @@ final class ModelDecodingTests: XCTestCase {
         let response = try decode(ServiceControlResponse.self, #"{ "status": true }"#)
         XCTAssertTrue(response.status)
     }
+
+    // MARK: /api/ap
+
+    func testAPControlRequestEncoding() throws {
+        let request = APControlRequest(mode: "on", revertMinutes: 10)
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(object["mode"] as? String, "on")
+        XCTAssertEqual(object["revertMinutes"] as? Int, 10)
+    }
+
+    func testAPControlRequestOmitsRevertWhenNil() throws {
+        let request = APControlRequest(mode: "status", revertMinutes: nil)
+        let encoded = try JSONEncoder().encode(request)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        XCTAssertEqual(object["mode"] as? String, "status")
+        XCTAssertNil(object["revertMinutes"])
+    }
+
+    func testAPStatusResponseDecoding() throws {
+        let response = try decode(APStatusResponse.self, #"{ "ap": "on" }"#)
+        XCTAssertEqual(response.ap, "on")
+    }
+
+    func testAPActionResponseDecoding() throws {
+        let response = try decode(
+            APActionResponse.self,
+            #"{ "result": "ok", "mode": "off", "output": "Reconnecting to WiFi 'Livebox-98D4'..." }"#)
+        XCTAssertEqual(response.result, "ok")
+        XCTAssertEqual(response.mode, "off")
+        XCTAssertTrue(response.output.contains("Reconnecting"))
+    }
 }

--- a/scripts/deploy/ap-mode.sh
+++ b/scripts/deploy/ap-mode.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# Toggle the Pi's WiFi between client mode and access-point (hotspot) mode.
+# The Pi has a single radio, so AP and client are mutually exclusive:
+# turning the AP on disconnects upstream WiFi, and vice versa.
+#
+#   ap-mode.sh on [minutes]   Activate the hotspot AP. With an optional
+#                             integer <minutes>, schedule an automatic switch
+#                             back to WiFi after that long — handy for testing
+#                             so a bad switch can't strand the Pi headless.
+#   ap-mode.sh off            Reconnect to the primary upstream WiFi
+#                             (also cancels any pending auto-revert).
+#   ap-mode.sh status         Print "on" or "off".
+#
+# Profile names come from the shared controller/.env.wifi (HOTSPOT_CON,
+# WIFI_SSID). Activating connections uses NetworkManager's network-control
+# polkit action, granted to the service user by the deploy
+# (scripts/deploy/beatled-network.rules.template), so no sudo is needed.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+ROOT_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+SELF="$SCRIPT_DIR/$(basename -- "${BASH_SOURCE[0]}")"
+
+WIFI_ENV="$ROOT_DIR/controller/.env.wifi"
+if [[ -f "$WIFI_ENV" ]]; then
+  # shellcheck disable=SC1090
+  source "$WIFI_ENV"
+fi
+HOTSPOT_CON="${HOTSPOT_CON:-beatled-hotspot}"
+WIFI_SSID="${WIFI_SSID:-}"
+
+# Pending auto-revert is tracked here. ROOT_DIR is the one writable path under
+# the server's systemd sandbox (ReadWritePaths=$ROOT_DIR), so /tmp is not an
+# option when ap-mode is invoked via the server.
+REVERT_MARKER="$ROOT_DIR/.ap-revert.pid"
+
+is_ap_active() {
+  nmcli -t -f NAME con show --active 2>/dev/null | grep -qxF "$HOTSPOT_CON"
+}
+
+cancel_revert() {
+  [[ -f "$REVERT_MARKER" ]] || return 0
+  local pid
+  pid="$(cat "$REVERT_MARKER" 2>/dev/null || true)"
+  if [[ "$pid" =~ ^[0-9]+$ ]]; then
+    # setsid made the sleeper a process-group leader; signal the whole group
+    # (negative pid) so its sleep child dies with it.
+    kill -TERM -- "-${pid}" 2>/dev/null || true
+  fi
+  rm -f "$REVERT_MARKER"
+}
+
+schedule_revert() {
+  local minutes="$1"
+  cancel_revert
+  # Detach fully (setsid + closed/redirected fds) so the timer survives this
+  # script exec'ing into nmcli, the SSH session dropping, and the HTTP
+  # connection closing. It removes the marker *before* invoking off, so off's
+  # own cancel_revert doesn't kill the revert run itself.
+  REVERT_SECS="$((minutes * 60))" REVERT_MARKER="$REVERT_MARKER" SELF="$SELF" \
+    setsid bash -c 'echo $$ > "$REVERT_MARKER"; sleep "$REVERT_SECS"; rm -f "$REVERT_MARKER"; exec "$SELF" off' \
+    </dev/null >>"$ROOT_DIR/.ap-revert.log" 2>&1 &
+  echo "Auto-revert to WiFi scheduled in ${minutes} min."
+}
+
+case "${1:-status}" in
+  on)
+    revert="${2:-0}"
+    if [[ ! "$revert" =~ ^[0-9]+$ ]]; then
+      echo "revert minutes must be a non-negative integer" >&2
+      exit 1
+    fi
+    if ((revert > 0)); then
+      schedule_revert "$revert"
+    fi
+    echo "Activating AP '$HOTSPOT_CON' (this drops upstream WiFi)..."
+    exec nmcli con up "$HOTSPOT_CON"
+    ;;
+  off)
+    cancel_revert
+    if [[ -z "$WIFI_SSID" ]]; then
+      echo "No WIFI_SSID configured; bringing the AP down instead." >&2
+      exec nmcli con down "$HOTSPOT_CON"
+    fi
+    echo "Reconnecting to upstream WiFi '$WIFI_SSID'..."
+    exec nmcli con up "$WIFI_SSID"
+    ;;
+  status)
+    if is_ap_active; then echo "on"; else echo "off"; fi
+    ;;
+  *)
+    echo "usage: ap-mode.sh <on [minutes]|off|status>" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/deploy/beatled-network.rules.template
+++ b/scripts/deploy/beatled-network.rules.template
@@ -1,0 +1,25 @@
+// Allow the beatled service user to activate/deactivate NetworkManager
+// connections (WiFi client <-> hotspot AP) from a session-less systemd
+// service, without sudo. Scoped to just the NetworkManager actions the
+// WiFi-fallback / ap-mode flow needs — nothing else is granted.
+//
+// Without this, NetworkManager denies a headless service ("Not authorized
+// to control networking"), since polkit only implicitly allows real login
+// sessions. Installed to /etc/polkit-1/rules.d/50-beatled-network.rules,
+// generated from this template by install-service.sh (envsubst).
+//
+// Actions:
+//   network-control       — bring connections up/down (client <-> AP).
+//   wifi.share.protected  — activate the password-protected hotspot, whose
+//   wifi.share.open         ipv4.method=shared needs the "share" privilege
+//                           on top of network-control. Without these, AP
+//                           activation fails with "Not authorized to share
+//                           connections via wifi".
+polkit.addRule(function(action, subject) {
+    if (subject.user == "${USERNAME}" &&
+        (action.id == "org.freedesktop.NetworkManager.network-control" ||
+         action.id == "org.freedesktop.NetworkManager.wifi.share.protected" ||
+         action.id == "org.freedesktop.NetworkManager.wifi.share.open")) {
+        return polkit.Result.YES;
+    }
+});

--- a/scripts/deploy/install-service.sh
+++ b/scripts/deploy/install-service.sh
@@ -105,8 +105,16 @@ install_service() {
 
 info "Installing services (ROOT_DIR=$ROOT_DIR, networks=[${WIFI_CONNECTIONS:-none}], HOTSPOT_CON=$HOTSPOT_CON, MDNS_ALIAS=$MDNS_ALIAS)"
 
-# These are executed by their services; make sure they're runnable.
-chmod +x "$SCRIPT_DIR/wifi-fallback.sh" "$SCRIPT_DIR/avahi-alias.sh"
+# These are executed by their services / the API; make sure they're runnable.
+chmod +x "$SCRIPT_DIR/wifi-fallback.sh" "$SCRIPT_DIR/avahi-alias.sh" "$SCRIPT_DIR/ap-mode.sh"
+
+# polkit rule: lets the service user activate NetworkManager connections
+# (wifi-fallback at boot, ap-mode on demand) without sudo or an interactive
+# session. polkitd watches rules.d and reloads automatically.
+info "Installing polkit rule for NetworkManager control (user $USERNAME)"
+envsubst < "$SCRIPT_DIR/beatled-network.rules.template" > "$SCRIPT_DIR/beatled-network.rules"
+sudo cp "$SCRIPT_DIR/beatled-network.rules" /etc/polkit-1/rules.d/50-beatled-network.rules
+sudo chmod 644 /etc/polkit-1/rules.d/50-beatled-network.rules
 
 install_service beat-server
 install_service wifi-fallback enable

--- a/server/src/server/http/api_handler.cpp
+++ b/server/src/server/http/api_handler.cpp
@@ -1,7 +1,10 @@
+#include <array>
+#include <cstdio>
 #include <iomanip>
 #include <limits>
 #include <nlohmann/json.hpp>
 #include <sstream>
+#include <sys/wait.h>
 
 #include "./api_handler.hpp"
 #include "beatled/protocol.h"
@@ -11,6 +14,40 @@ using beatled::core::tempo_ref_t;
 
 namespace beatled::server {
 
+namespace {
+struct CommandResult {
+  int exit_code;
+  std::string output;
+};
+
+// Run a shell command, capturing stdout+stderr and the exit code. Used only
+// for the AP-mode toggle (ap-mode.sh). The single caller-controlled part of
+// the command line is whitelisted (mode) or an integer (revert minutes), so
+// there is no shell-injection surface.
+CommandResult run_command(const std::string &cmd) {
+  std::array<char, 256> buf{};
+  std::string out;
+  FILE *pipe = ::popen(cmd.c_str(), "r");
+  if (pipe == nullptr) {
+    return {-1, "failed to start command"};
+  }
+  while (std::fgets(buf.data(), static_cast<int>(buf.size()), pipe) != nullptr) {
+    out += buf.data();
+  }
+  int status = ::pclose(pipe);
+  int code = (status == -1) ? -1 : (WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+  return {code, out};
+}
+
+std::string rstrip(std::string s) {
+  while (!s.empty() &&
+         (s.back() == '\n' || s.back() == '\r' || s.back() == ' ' || s.back() == '\t')) {
+    s.pop_back();
+  }
+  return s;
+}
+} // namespace
+
 struct Program {
   std::string name;
   int id;
@@ -19,9 +56,9 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Program, name, id)
 
 APIHandler::APIHandler(ServiceManagerInterface &service_manager, Logger &logger,
                        const std::string &cors_origin, const std::string &api_token,
-                       QosThresholds qos_thresholds)
+                       QosThresholds qos_thresholds, const std::string &ap_script)
     : service_manager_{service_manager}, logger_{logger}, cors_origin_{cors_origin},
-      api_token_{api_token}, qos_thresholds_{qos_thresholds} {}
+      api_token_{api_token}, qos_thresholds_{qos_thresholds}, ap_script_{ap_script} {}
 
 bool APIHandler::authorize_request(const std::optional<std::string> &authorization_header,
                                    std::string_view api_token) {
@@ -152,6 +189,103 @@ APIHandler::req_status_t APIHandler::on_post_service_control(const req_handle_t 
     response_body["error"] = e.what();
 
     SPDLOG_ERROR("Error with request: {}", e.what());
+    return init_resp(req->create_response(restinio::status_bad_request()))
+        .set_body(response_body.dump())
+        .connection_close()
+        .done();
+  }
+}
+
+APIHandler::req_status_t APIHandler::on_post_ap(const req_handle_t &req, route_params_t params) {
+  if (!check_auth(req)) {
+    return init_resp(req->create_response(restinio::status_unauthorized()))
+        .set_body(R"({"error":"Unauthorized"})")
+        .done();
+  }
+  if (!check_rate_limit()) {
+    return init_resp(req->create_response(restinio::status_too_many_requests()))
+        .set_body(R"({"error":"Too many requests"})")
+        .done();
+  }
+
+  json response_body;
+  try {
+    if (req->body().size() > 4096) {
+      response_body["error"] = "Request body too large";
+      return init_resp(req->create_response(restinio::status_bad_request()))
+          .set_body(response_body.dump())
+          .connection_close()
+          .done();
+    }
+    json request_body = json::parse(req->body());
+    if (!request_body.contains("mode")) {
+      response_body["error"] = "Missing required field: mode";
+      return init_resp(req->create_response(restinio::status_bad_request()))
+          .set_body(response_body.dump())
+          .connection_close()
+          .done();
+    }
+    std::string mode = request_body["mode"].get<std::string>();
+    // Whitelist: mode is part of the command line, so restrict it to these
+    // three tokens to keep the shell-out injection-free.
+    if (mode != "on" && mode != "off" && mode != "status") {
+      response_body["error"] = "Invalid mode (expected on, off, or status)";
+      return init_resp(req->create_response(restinio::status_bad_request()))
+          .set_body(response_body.dump())
+          .connection_close()
+          .done();
+    }
+
+    std::string cmd = ap_script_ + " " + mode;
+    // Optional auto-revert (only meaningful for "on"): an integer number of
+    // minutes after which the Pi switches back to WiFi. It arrives as a JSON
+    // number and is re-serialized via std::to_string, so it can only be
+    // digits — no injection.
+    if (mode == "on" && request_body.contains("revertMinutes")) {
+      int revert = request_body["revertMinutes"].get<int>();
+      if (revert < 0 || revert > 1440) {
+        response_body["error"] = "revertMinutes out of range (0-1440)";
+        return init_resp(req->create_response(restinio::status_bad_request()))
+            .set_body(response_body.dump())
+            .connection_close()
+            .done();
+      }
+      if (revert > 0) {
+        cmd += " " + std::to_string(revert);
+      }
+    }
+
+    SPDLOG_INFO("AP mode request: {}", cmd);
+    // NOTE: "on" switches wlan0 to AP mode, tearing down the link this request
+    // arrived over — the client must rejoin the hotspot to see any response.
+    // The handler still completes server-side.
+    CommandResult result = run_command(cmd + " 2>&1");
+    std::string out = rstrip(result.output);
+
+    if (result.exit_code != 0) {
+      response_body["error"] = "ap-mode.sh failed";
+      response_body["mode"] = mode;
+      response_body["exitCode"] = result.exit_code;
+      response_body["output"] = out;
+      SPDLOG_ERROR("ap-mode.sh failed (exit {}): {}", result.exit_code, out);
+      return init_resp(req->create_response(restinio::status_internal_server_error()))
+          .set_body(response_body.dump())
+          .done();
+    }
+
+    if (mode == "status") {
+      response_body["ap"] = out; // "on" or "off"
+    } else {
+      response_body["result"] = "ok";
+      response_body["mode"] = mode;
+      response_body["output"] = out;
+    }
+    return init_resp(req->create_response(restinio::status_ok()))
+        .set_body(response_body.dump())
+        .done();
+  } catch (const std::exception &e) {
+    response_body["error"] = e.what();
+    SPDLOG_ERROR("Error with AP request: {}", e.what());
     return init_resp(req->create_response(restinio::status_bad_request()))
         .set_body(response_body.dump())
         .connection_close()

--- a/server/src/server/http/api_handler.hpp
+++ b/server/src/server/http/api_handler.hpp
@@ -36,11 +36,16 @@ public:
 
   APIHandler(ServiceManagerInterface &service_manager, Logger &logger,
              const std::string &cors_origin = "", const std::string &api_token = "",
-             QosThresholds qos_thresholds = QosThresholds{});
+             QosThresholds qos_thresholds = QosThresholds{},
+             const std::string &ap_script = "scripts/deploy/ap-mode.sh");
 
   req_status_t on_get_status(const req_handle_t &req, route_params_t params);
 
   req_status_t on_post_service_control(const req_handle_t &req, route_params_t params);
+
+  // Toggle the Pi's WiFi between client and access-point mode by shelling
+  // out to ap-mode.sh. Body: {"mode": "on"|"off"|"status"}.
+  req_status_t on_post_ap(const req_handle_t &req, route_params_t params);
 
   req_status_t on_get_tempo(const req_handle_t &req, route_params_t params);
   req_status_t on_post_manual_tempo(const req_handle_t &req, route_params_t params);
@@ -83,6 +88,7 @@ private:
   std::string cors_origin_;
   std::string api_token_;
   QosThresholds qos_thresholds_;
+  std::string ap_script_;
 
   // Rate limiting: sliding window
   static constexpr size_t kMaxRequestsPerWindow = 60;

--- a/server/src/server/http/http_server.cpp
+++ b/server/src/server/http/http_server.cpp
@@ -68,6 +68,8 @@ std::unique_ptr<router_t> HTTPServer::server_handler(const std::string &root_dir
 
   router->http_post("/api/service/control", by_api_handler(&APIHandler::on_post_service_control));
 
+  router->http_post("/api/ap", by_api_handler(&APIHandler::on_post_ap));
+
   router->http_get("/api/tempo", by_api_handler(&APIHandler::on_get_tempo));
 
   router->http_post("/api/tempo/manual", by_api_handler(&APIHandler::on_post_manual_tempo));


### PR DESCRIPTION
Exposes the Pi's WiFi ⇄ hotspot switch over the HTTP API so operators can flip the box into its own `Beatled` access point (and back) from the clients instead of SSH-ing in. Built server-first per the API-stability convention, with the React and iOS consumers in following commits.

## Server + deploy (`2798c49`)
- **`POST /api/ap`** — body `{"mode": "on"|"off"|"status", "revertMinutes"?: 0–1440}`. `on` activates the hotspot (tearing down the upstream link this request arrived on), `off` reconnects to WiFi, `status` reports `on`/`off`. The handler validates `mode` against a whitelist and re-serializes `revertMinutes` via `std::to_string`, so the `popen` shell-out has **no injection surface**. The script path is injected for testability.
- **`ap-mode.sh`** — `on`/`off`/`status` with an optional auto-revert timer so a bad switch can't strand a headless Pi; reads `HOTSPOT_CON`/`WIFI_SSID` from the shared `controller/.env.wifi`.
- **polkit rule** (`beatled-network.rules`, installed by `install-service.sh`) grants the service user `network-control` **and** `wifi.share.protected`/`open`. The `wifi.share` actions are required because the hotspot is `ipv4.method=shared` — without them, AP activation fails with *"Not authorized to share connections via wifi."*
- `docs/api.markdown` documents the endpoint.

## React client (`f23561e`)
`lib/ap.ts` (typed client + unit tests), wired into `lib/api.ts`, and AP controls in `views/config.tsx` with a "you'll be disconnected" warning.

## iOS/macOS app (`cfb265d`)
`APControl` models, `ConfigViewModel`/`ConfigView` AP section, registered in the project, with decoding + view-model tests.

## Verification
- ✅ Server Catch2 suite passes (all groups green).
- ✅ React AP unit tests pass (4/4 via vitest).
- ⏳ iOS tests **not** run here (no Xcode/simulator in this environment) — matches the known "iOS untested + no iOS CI" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)