### PR TITLE
Restart avahi-alias on IP change via a NetworkManager dispatcher

### DIFF
--- a/scripts/deploy/avahi-alias-dispatcher.sh
+++ b/scripts/deploy/avahi-alias-dispatcher.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# NetworkManager dispatcher: re-publish the mDNS alias after the host's IP
+# changes. avahi-alias.service holds a *static* A record (avahi-publish -a
+# <name> <ip>), captured once at startup — so when the address changes (boot,
+# ap-mode on/off, wifi-fallback, a DHCP renewal) it keeps advertising the old
+# IP until restarted. NM runs this as root on every connectivity transition,
+# so restarting the unit here needs no sudo/polkit.
+#
+# NetworkManager invokes dispatcher scripts as:  <script> <interface> <action>
+#
+# Installed (by install-service.sh) to
+# /etc/NetworkManager/dispatcher.d/90-beatled-avahi-alias, root-owned and not
+# group/world-writable — NM silently ignores scripts that aren't.
+set -u
+
+action="${2:-}"
+
+case "$action" in
+  up | dhcp4-change | dhcp6-change | connectivity-change)
+    # --no-block so we don't stall NM's dispatcher run; restart (not
+    # try-restart) so the alias comes back even if it had failed/stopped.
+    # Restarting a unit isn't a network event, so this can't loop.
+    systemctl --no-block restart avahi-alias.service
+    ;;
+esac

--- a/scripts/deploy/install-service.sh
+++ b/scripts/deploy/install-service.sh
@@ -7,6 +7,9 @@
 # The avahi-alias service publishes an extra mDNS name so the Pi answers to
 # <MDNS_ALIAS> in addition to <hostname>.local. Override the name via the
 # environment (or controller/.env.wifi): MDNS_ALIAS (default beatled.local).
+# A NetworkManager dispatcher restarts that service whenever the host IP
+# changes (ap-mode switch, wifi-fallback, DHCP renewal) so the alias never
+# advertises a stale address.
 #
 # The wifi-fallback service brings up known NetworkManager connections on
 # boot — the WiFi networks defined once in controller/.env.wifi, tried in
@@ -121,3 +124,12 @@ install_service wifi-fallback enable
 # Publishing an mDNS record doesn't touch the network link, so it's safe to
 # start now (unlike wifi-fallback, which would bounce the deploy's WiFi).
 install_service avahi-alias
+
+# NetworkManager dispatcher: re-publish the mDNS alias whenever the host IP
+# changes (ap-mode switch, wifi-fallback, DHCP renewal), since avahi-alias
+# holds a static A record that would otherwise go stale. NM runs it as root,
+# and ignores dispatcher scripts that aren't root-owned / are group- or
+# world-writable, so install with strict ownership and perms.
+info "Installing NetworkManager dispatcher for avahi-alias"
+sudo install -o root -g root -m 755 "$SCRIPT_DIR/avahi-alias-dispatcher.sh" \
+  /etc/NetworkManager/dispatcher.d/90-beatled-avahi-alias


### PR DESCRIPTION
## Problem

When the Pi switched to its hotspot (`ap-mode on`), `beatled.local` kept resolving to the **stale** Livebox-subnet IP (`192.168.1.51`) and was unreachable from the hotspot's `192.168.4.x` network — while `raspberrypi.local` correctly resolved to the hotspot gateway (`192.168.4.1`).

**Cause:** `avahi-alias.service` publishes a *static* A record (`avahi-publish -a <name> <ip>`), capturing the IP once at startup. The host's primary name is managed by `avahi-daemon` and tracks the active interface, but the alias does not. The unit's `Restart=always` doesn't help — `avahi-publish` doesn't exit on an IP change, so nothing restarts it.

## Fix

Add a **NetworkManager dispatcher** (`/etc/NetworkManager/dispatcher.d/90-beatled-avahi-alias`) that restarts `avahi-alias.service` on `up` / `dhcp4-change` / `dhcp6-change` / `connectivity-change`. NM runs dispatcher scripts as **root**, so no sudo/polkit is needed, and it covers every IP transition uniformly: boot, `ap-mode on/off`, `wifi-fallback`, and DHCP renewals.

`install-service.sh` installs it root-owned, mode 755 (NM silently ignores dispatcher scripts that are group/world-writable or not root-owned). Restart uses `systemctl --no-block restart` so it doesn't stall NM's dispatcher run, and restarting a unit isn't a network event, so it can't loop.

## Verification
- `bash -n` clean on both scripts.
- Behavioural verification is on-device after redeploy: switch `ap-mode on`, then from a client on the hotspot confirm `beatled.local` now resolves to `192.168.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)