### PR TITLE
Fix PortAudio status log to use fmt placeholders

### DIFF
--- a/server/src/beat_detector/audio/audio_input.cpp
+++ b/server/src/beat_detector/audio/audio_input.cpp
@@ -64,7 +64,12 @@ int AudioInput::paCallbackMethod(const void *inputBuffer, void *outputBuffer,
   copy_to_buffer(input, frameCount, timeInfo->inputBufferAdcTime, timeInfo->currentTime);
 
   if (statusFlags) {
-    SPDLOG_ERROR(" *** PortAudio stream status %lu", statusFlags);
+    // spdlog uses fmt-style {} placeholders, not printf %lu. Log the raw
+    // bitmask plus the input flags that actually matter here — both mean
+    // dropped audio frames on an input-only stream.
+    SPDLOG_ERROR(" *** PortAudio stream status {:#x}{}{}", statusFlags,
+                 (statusFlags & paInputUnderflow) ? " input-underflow" : "",
+                 (statusFlags & paInputOverflow) ? " input-overflow" : "");
   }
   (void)outputBuffer;
 


### PR DESCRIPTION
The stream-status callback in `audio_input.cpp` logged with a printf-style `%lu`, but spdlog uses fmt-style `{}` — so the flag value was dropped and the literal `%lu` was printed (`*** PortAudio stream status %lu`).

Use a `{}` placeholder, log the raw bitmask in hex, and decode the input under/overflow flags — both mean dropped audio frames on this input-only stream.

Verified: `./beatled.sh server build` compiles clean (fmt's compile-time format check passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)