### PR TITLE
Fix manual firmware build docs to export .env vars

### DIFF
--- a/docs/controller.markdown
+++ b/docs/controller.markdown
@@ -97,8 +97,13 @@ Then configure and build (the build wrapper sources `.env.wifi` before
 
 ```bash
 export PICO_TOOLCHAIN_PATH="/Applications/ArmGNUToolchain/12.2.rel1/arm-none-eabi"
-source .env.wifi   # sets WIFI_SSID, WIFI_PASSWORD (+ _2..4 fallbacks)
-source .env.pico   # sets BEATLED_SERVER_NAME, NUM_PIXELS, WS2812_PIN
+# `set -a` exports every var so CMake picks them up from the environment
+# ($ENV{WIFI_SSID} etc.) — a plain `source` would set but not export them,
+# baking in empty WiFi credentials.
+set -a
+source .env.wifi   # WIFI_SSID/WIFI_PASSWORD (+ _2..4 fallbacks, HOTSPOT_*)
+source .env.pico   # BEATLED_SERVER_NAME, NUM_PIXELS, WS2812_PIN
+set +a
 
 cmake -B build-pico \
   -DPORT=pico \
@@ -187,14 +192,16 @@ Or manually:
 
 ```bash
 cd esp32
+# `set -a` exports every var so idf.py / CMake read them from the
+# environment ($ENV{WIFI_SSID} etc.), including the _2..4 fallbacks and
+# HOTSPOT_SSID/HOTSPOT_PASSWORD.
+set -a
 source ../.env.wifi
 source ../.env.esp32
+set +a
 
 idf.py set-target $ESP32_TARGET
-WIFI_SSID="$WIFI_SSID" WIFI_PASSWORD="$WIFI_PASSWORD" \
-  BEATLED_SERVER_NAME="$BEATLED_SERVER_NAME" \
-  NUM_PIXELS="$NUM_PIXELS" WS2812_PIN="$WS2812_PIN" \
-  idf.py build flash monitor -p $ESP32_PORT
+idf.py build flash monitor -p $ESP32_PORT
 ```
 
 ### Flash & Monitor


### PR DESCRIPTION
Following the **manual** (non-`beatled.sh`) build instructions in `controller.markdown` verbatim produced broken firmware:

- **Pico**: `source .env.wifi` sets but doesn't *export* the vars, yet `controller/CMakeLists.txt` reads them from `$ENV{WIFI_SSID}` — so the build baked in **empty** WiFi credentials.
- **ESP32**: the explicit `WIFI_SSID=… WIFI_PASSWORD=…` list predated the `_2..4` fallbacks and the new `HOTSPOT_SSID`/`HOTSPOT_PASSWORD`, so those were silently dropped.

Wrap the `source` lines in `set -a` / `set +a` (matching what `beatled.sh` does), so every `.env` var — current and future — exports to the build environment, and drop the now-redundant explicit var list from the `idf.py` call.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)