### PR TITLE
Make Pi boot-time networking survive device/IP races

### DIFF
--- a/scripts/deploy/avahi-alias.sh
+++ b/scripts/deploy/avahi-alias.sh
@@ -14,9 +14,20 @@ ALIAS="${1:?usage: avahi-alias.sh <alias.local>}"
 # avahi-publish -a registers an A record, so it needs the current IP. Take
 # the first non-loopback address (wlan0 / eth0). If the lease changes, the
 # unit is restarted (Restart=always) and re-resolves.
-IP="$(hostname -I | awk '{print $1}')"
+#
+# On a cold boot or an AP->Wi-Fi handoff the address often isn't up yet when
+# this unit starts. Rather than exit 1 (which turns the boot race into a
+# restart storm), wait for an IP to appear. The dispatcher will restart us on
+# the next connectivity event regardless, so this only needs to cover the
+# initial gap; cap the wait so a genuinely network-less host still fails loudly.
+IP=""
+for _ in $(seq 1 30); do
+  IP="$(hostname -I | awk '{print $1}')"
+  [[ -n "$IP" ]] && break
+  sleep 1
+done
 if [[ -z "$IP" ]]; then
-  echo "avahi-alias: no IP address yet for $ALIAS" >&2
+  echo "avahi-alias: no IP address after 30s for $ALIAS" >&2
   exit 1
 fi
 

--- a/scripts/deploy/avahi-alias.template.service
+++ b/scripts/deploy/avahi-alias.template.service
@@ -3,6 +3,13 @@ Description=Publish an extra mDNS .local alias for this host
 After=network-online.target avahi-daemon.service
 Wants=network-online.target
 Requires=avahi-daemon.service
+# An AP->Wi-Fi handoff (boot, wifi-fallback, ap-mode) makes the NM dispatcher
+# fire several `systemctl restart` events in the same second, and Restart=always
+# adds its own retries on top. Without disabling the start limit, that burst
+# trips systemd's default (5 starts / 10s) and latches the unit 'failed', so the
+# alias stays unpublished until a manual reset-failed. Disable the limit so the
+# unit always keeps retrying until an IP exists and the name sticks.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple

--- a/scripts/deploy/wifi-fallback.sh
+++ b/scripts/deploy/wifi-fallback.sh
@@ -13,6 +13,24 @@ HOTSPOT_CON="${1:?usage: wifi-fallback.sh <hotspot-connection> [<wifi-connection
 shift
 TIMEOUT="${TIMEOUT:-30}"
 
+# On a cold boot the Wi-Fi radio (wlan0) is often not enumerated/managed yet
+# when this unit runs — ordering After=NetworkManager.service only guarantees
+# the daemon is up, not that the device exists. `nmcli con up` then fails fast
+# with "no suitable device found (device eth0 not available ...)" because the
+# only managed device is eth0, and --wait does NOT cover this case (it waits
+# for an *existing* device to activate, not for one to appear). Without this
+# guard we'd skip every Wi-Fi profile and drop straight to the hotspot. Wait
+# for a Wi-Fi device to leave the 'unavailable' state before trying profiles.
+echo "Waiting for a Wi-Fi device to become available (timeout ${TIMEOUT}s)..."
+for _ in $(seq 1 "$TIMEOUT"); do
+    wifi_state="$(nmcli -t -f TYPE,STATE dev status | awk -F: '$1=="wifi"{print $2; exit}')"
+    [[ -n "$wifi_state" && "$wifi_state" != "unavailable" ]] && break
+    sleep 1
+done
+if [[ -z "${wifi_state:-}" || "$wifi_state" == "unavailable" ]]; then
+    echo "No Wi-Fi device ready after ${TIMEOUT}s; proceeding anyway." >&2
+fi
+
 for con in "$@"; do
     echo "Trying to connect to '$con' (timeout ${TIMEOUT}s)..."
     if nmcli --wait "$TIMEOUT" con up "$con"; then


### PR DESCRIPTION
## Summary

Three cold-boot failure modes observed on the Raspberry Pi, all rooted in deploy services racing ahead of the network coming up. Diagnosed from `journalctl` after a reboot left `beatled.local` unreachable and Wi-Fi falling back to the hotspot.

### 1. `avahi-alias.service` latched `failed` after an AP→Wi-Fi handoff
The NM dispatcher fires several `systemctl restart` events in the same second during the handoff, and `Restart=always` adds its own retries. Without a disabled start limit, that burst trips systemd's default (5 starts / 10s) and the unit gives up — leaving `beatled.local` unpublished until a manual `reset-failed`.
**Fix:** `StartLimitIntervalSec=0` in the unit (matches `beat-server.template.service`).

### 2. `avahi-alias.sh` exited on a transient no-IP condition
Exiting 1 the instant `hostname -I` was empty turned the normal boot race into restart churn.
**Fix:** poll for an IP for up to 30s so a single invocation rides out the handoff.

### 3. `wifi-fallback.sh` tried to connect before `wlan0` existed
At ~2s into boot the only managed device is `eth0`, so `nmcli con up <ssid>` fails fast with "no suitable device found" (`--wait` does not cover a device that doesn't yet exist) and drops straight to the hotspot.
**Fix:** wait for a Wi-Fi device to leave the `unavailable` state before trying profiles.

## Testing

Built the ARM64 tarball and deployed to the Pi (`raspberrypi.local`). Verified live:
- `systemctl show avahi-alias.service -p StartLimitIntervalUSec` → `0`
- `avahi-alias.service` active; `avahi-resolve -n beatled.local` → `192.168.1.51`
- both scripts carry the new wait loops
- `beat-server.service` still active; health check passed

A real reboot is the final proof for the race fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)