### PR TITLE
Add per-boot epoch to NEXT_BEAT/PROGRAM/BEAT (protocol v5)

### DIFF
--- a/controller/lib/beatled_protocol/include/beatled/protocol.h
+++ b/controller/lib/beatled_protocol/include/beatled/protocol.h
@@ -25,7 +25,7 @@ extern "C" {
 // reserved forever as {version_major, version_minor}. A server of any
 // major version can therefore always read the peer's major version, even
 // when the rest of the message layout has changed.
-#define BEATLED_PROTOCOL_VERSION_MAJOR 4
+#define BEATLED_PROTOCOL_VERSION_MAJOR 5
 #define BEATLED_PROTOCOL_VERSION_MINOR 0
 
 typedef enum {
@@ -161,10 +161,19 @@ typedef struct {
 // out-of-order pushes. The server emits one on every program change plus a
 // low-rate (~1 Hz) refresh so late joiners and packet-loss don't strand
 // controllers on a wrong pattern.
+//
+// Protocol v5: trails `seq` with a per-server-boot `epoch`. `seq` resets to a
+// low value every time the server process restarts, so a controller that
+// outlived the restart would reject every fresh push as "stale" (delta < 0)
+// until the counter climbed back past its last-seen value — stranding it on
+// the wrong pattern for up to ~an hour. The epoch is a random value picked
+// once at server startup; when a controller sees a new epoch it adopts the
+// incoming `seq` unconditionally instead of comparing against the old run's.
 typedef struct {
   beatled_message_t base;
   uint16_t program_id;
   uint16_t seq;
+  uint32_t epoch;
 } __attribute__((__packed__)) beatled_message_program_t;
 
 // eCommandType = BEATLED_MESSAGE_NEXT_BEAT
@@ -178,22 +187,31 @@ typedef struct {
 // (not of the beat during which the message was sent). Controllers fold it
 // into their local beat grid so patterns keyed on the count stay phase-
 // continuous across re-anchors.
+//
+// Protocol v5: trails `seq` with the same per-server-boot `epoch` as PROGRAM
+// (see beatled_message_program_t). On an epoch change the controller resets
+// its seq-gap tracking instead of treating the post-restart `seq` reset as a
+// flood of dropped beats.
 typedef struct {
   beatled_message_t base;
   uint64_t next_beat_time_ref;
   uint32_t beat_count;
   uint16_t seq;
+  uint32_t epoch;
 } __attribute__((__packed__)) beatled_message_next_beat_t;
 
 // eCommandType = BEATLED_MESSAGE_BEAT
 //
 // Same shape as NEXT_BEAT; currently unused by the live system but kept in
 // the catalogue for parity with the beat-detector callback structure.
+// Protocol v5: carries the per-server-boot `epoch` for wire parity with
+// NEXT_BEAT even though the live server doesn't emit BEAT.
 typedef struct {
   beatled_message_t base;
   uint64_t beat_time_ref;
   uint32_t beat_count;
   uint16_t seq;
+  uint32_t epoch;
 } __attribute__((__packed__)) beatled_message_beat_t;
 
 // eCommandType = BEATLED_MESSAGE_STATUS_REQUEST

--- a/controller/src/command/command.c
+++ b/controller/src/command/command.c
@@ -18,7 +18,11 @@
 
 // Track the last-seen PROGRAM sequence number to drop late duplicates.
 // Unlike NEXT_BEAT we don't count gaps — PROGRAM repeats every 1s anyway.
+// `last_program_epoch` scopes the seq comparison to one server-boot (v5): a
+// new epoch means the server restarted and reset its seq, so we must not treat
+// the reset as "stale".
 static uint16_t last_program_seq = 0;
+static uint32_t last_program_epoch = 0;
 static bool have_seen_program = false;
 
 int command_program(beatled_message_t *server_msg, size_t data_length) {
@@ -29,8 +33,12 @@ int command_program(beatled_message_t *server_msg, size_t data_length) {
 
   uint16_t program_id = ntohs(program_msg->program_id);
   uint16_t seq = ntohs(program_msg->seq);
+  uint32_t epoch = ntohl(program_msg->epoch);
 
-  if (have_seen_program) {
+  // Only compare seq within the same server-boot epoch. On a new epoch the
+  // server has restarted (and reset its seq counter), so adopt the incoming
+  // seq unconditionally instead of rejecting it as stale.
+  if (have_seen_program && epoch == last_program_epoch) {
     int16_t delta = (int16_t)(seq - last_program_seq);
     if (delta < 0) {
       // Older than what we've applied — ignore.
@@ -38,6 +46,7 @@ int command_program(beatled_message_t *server_msg, size_t data_length) {
     }
   }
   last_program_seq = seq;
+  last_program_epoch = epoch;
   have_seen_program = true;
 
   printf("[CMD] Program push: id=%u seq=%u\n", program_id, seq);

--- a/controller/src/command/next_beat/next_beat.c
+++ b/controller/src/command/next_beat/next_beat.c
@@ -15,6 +15,7 @@
 // Track the last-seen sequence number to detect packet loss. Wraparound is
 // handled by treating the signed 16-bit difference as the actual increment.
 static uint16_t last_next_beat_seq = 0;
+static uint32_t last_next_beat_epoch = 0;
 static bool have_seen_next_beat = false;
 static uint32_t next_beat_gap_total = 0;
 
@@ -39,9 +40,13 @@ int process_next_beat_msg(beatled_message_t *server_msg, size_t data_length) {
       server_time_to_local_time(ntohll(next_beat_msg->next_beat_time_ref));
   uint32_t beat_count = ntohl(next_beat_msg->beat_count);
   uint16_t seq = ntohs(next_beat_msg->seq);
+  uint32_t epoch = ntohl(next_beat_msg->epoch);
 
-  // Sequence-gap accounting. (int16_t) cast handles 16-bit wrap correctly.
-  if (have_seen_next_beat) {
+  // Sequence-gap accounting, scoped to one server-boot epoch. (int16_t) cast
+  // handles 16-bit wrap correctly. A new epoch means the server restarted and
+  // reset its seq counter; re-anchor without rejecting the message or logging
+  // the reset as a flood of lost beats (see protocol v5).
+  if (have_seen_next_beat && epoch == last_next_beat_epoch) {
     int16_t delta = (int16_t)(seq - last_next_beat_seq);
     if (delta <= 0) {
       // Stale or duplicate (older or same seq) — drop without applying.
@@ -60,6 +65,7 @@ int process_next_beat_msg(beatled_message_t *server_msg, size_t data_length) {
     }
   }
   last_next_beat_seq = seq;
+  last_next_beat_epoch = epoch;
   have_seen_next_beat = true;
 
 #if BEATLED_VERBOSE_LOG

--- a/controller/tests/posix/integration/test_integration.cpp
+++ b/controller/tests/posix/integration/test_integration.cpp
@@ -437,6 +437,46 @@ TEST_CASE("Program change updates registry and queues intercore message", "[inte
   REQUIRE((ic.message_type & (0x01 << intercore_program_update)) != 0);
 }
 
+TEST_CASE("Program seq resets across a server-boot epoch change (v5)", "[integration]") {
+  init_system();
+  advance_to(STATE_TEMPO_SYNCED);
+  drain_intercore_queue();
+
+  // Epoch E1: apply program 5 at a high seq (simulating a long-running server).
+  beatled_message_program_t p1;
+  memset(&p1, 0, sizeof(p1));
+  p1.base.type = BEATLED_MESSAGE_PROGRAM;
+  p1.program_id = htons(5);
+  p1.seq = htons(30000);
+  p1.epoch = htonl(0x1111);
+  event_t e1 = make_server_event(&p1, sizeof(p1));
+  REQUIRE(handle_event(&e1) == 0);
+  REQUIRE(registry.program_id == 5);
+
+  // Same epoch, lower seq: a genuine stale/out-of-order push, must be ignored.
+  beatled_message_program_t p2;
+  memset(&p2, 0, sizeof(p2));
+  p2.base.type = BEATLED_MESSAGE_PROGRAM;
+  p2.program_id = htons(6);
+  p2.seq = htons(3);
+  p2.epoch = htonl(0x1111);
+  event_t e2 = make_server_event(&p2, sizeof(p2));
+  REQUIRE(handle_event(&e2) == 0);
+  REQUIRE(registry.program_id == 5); // unchanged — stale within the epoch
+
+  // New epoch (server restarted, seq counter reset to a low value): the low
+  // seq must NOT be rejected — this is exactly the stranding bug v5 fixes.
+  beatled_message_program_t p3;
+  memset(&p3, 0, sizeof(p3));
+  p3.base.type = BEATLED_MESSAGE_PROGRAM;
+  p3.program_id = htons(6);
+  p3.seq = htons(1);
+  p3.epoch = htonl(0x2222);
+  event_t e3 = make_server_event(&p3, sizeof(p3));
+  REQUIRE(handle_event(&e3) == 0);
+  REQUIRE(registry.program_id == 6); // applied — epoch change re-anchored seq
+}
+
 TEST_CASE("Error message handled without state change", "[integration]") {
   init_system();
   advance_to(STATE_REGISTERED);

--- a/controller/tests/posix/protocol/test_protocol.cpp
+++ b/controller/tests/posix/protocol/test_protocol.cpp
@@ -75,19 +75,19 @@ TEST_CASE("Protocol struct sizes match wire format", "[protocol]") {
     REQUIRE(sizeof(beatled_message_tempo_response_t) == 15);
   }
 
-  SECTION("Program message is 5 bytes (v2)") {
-    // 1 byte type + 2 bytes program_id + 2 bytes seq
-    REQUIRE(sizeof(beatled_message_program_t) == 5);
+  SECTION("Program message is 9 bytes (v5)") {
+    // 1 type + 2 program_id + 2 seq + 4 epoch
+    REQUIRE(sizeof(beatled_message_program_t) == 9);
   }
 
-  SECTION("Next beat message is 15 bytes (v2)") {
-    // base(1) + next_beat_time_ref(8) + beat_count(4) + seq(2) = 15
-    REQUIRE(sizeof(beatled_message_next_beat_t) == 15);
+  SECTION("Next beat message is 19 bytes (v5)") {
+    // base(1) + next_beat_time_ref(8) + beat_count(4) + seq(2) + epoch(4) = 19
+    REQUIRE(sizeof(beatled_message_next_beat_t) == 19);
   }
 
-  SECTION("Beat message is 15 bytes (v2)") {
+  SECTION("Beat message is 19 bytes (v5)") {
     // Same layout as next_beat
-    REQUIRE(sizeof(beatled_message_beat_t) == 15);
+    REQUIRE(sizeof(beatled_message_beat_t) == 19);
   }
 
   SECTION("Message type enum has expected count") {

--- a/docs/controller-sync.markdown
+++ b/docs/controller-sync.markdown
@@ -77,6 +77,8 @@ The server sends [NEXT_BEAT](protocol.html#next_beat-8) messages before each bea
 
 [PROGRAM](protocol.html#program-7) is now pushed by the server **on state change** (instant fan-out via a StateManager callback) plus a 5 Hz refresh, so late joiners and missed broadcasts don't strand controllers on a wrong pattern. Each NEXT_BEAT and PROGRAM carries a 16-bit `seq` that the controller uses to count loss and reject stale duplicates.
 
+Protocol v5 adds a 32-bit `epoch` to NEXT_BEAT, PROGRAM, and BEAT. The `seq` counters are per-process and reset to zero whenever the server restarts, so a controller that outlived the restart would otherwise reject every fresh push as "stale" (`delta < 0`) until the counter climbed back past its last-seen value — stranding it on the wrong pattern for up to ~an hour. The server picks a random `epoch` once at startup and stamps it on every message; the controller scopes its `seq` comparison to the current epoch and re-anchors (adopting the incoming `seq` unconditionally) the moment the epoch changes. The `seq` reset on restart is now self-healing rather than a stranding hazard.
+
 ### 5. QoS / diagnostics (protocol v4)
 
 Two complementary diagnostic channels feed `/api/devices.qos` and `/api/qos` so operators can see fleet sync health and catch silently-degrading controllers.

--- a/server/src/server/tempo_broadcaster/include/tempo_broadcaster/tempo_broadcaster.hpp
+++ b/server/src/server/tempo_broadcaster/include/tempo_broadcaster/tempo_broadcaster.hpp
@@ -91,6 +91,13 @@ private:
   std::atomic<uint16_t> next_beat_seq_{0};
   std::atomic<uint16_t> beat_seq_{0};
   std::atomic<uint16_t> program_seq_{0};
+
+  // Per-server-boot epoch (protocol v5), stamped on every NEXT_BEAT / BEAT /
+  // PROGRAM. The seq counters above reset to 0 on every process restart;
+  // carrying a fresh random epoch lets controllers that outlived the restart
+  // tell "the counter restarted" from "this push is stale" and re-anchor
+  // instead of rejecting every fresh push. Generated once in the ctor.
+  const uint32_t epoch_;
 };
 } // namespace beatled::server
 

--- a/server/src/server/tempo_broadcaster/tempo_broadcaster.cpp
+++ b/server/src/server/tempo_broadcaster/tempo_broadcaster.cpp
@@ -1,5 +1,6 @@
 #include <asio.hpp>
 #include <fmt/ostream.h>
+#include <random>
 #include <spdlog/spdlog.h>
 
 #include "core/clock.hpp"
@@ -28,8 +29,8 @@ TempoBroadcaster::TempoBroadcaster(const std::string &id, asio::io_context &io_c
           udp::endpoint(asio::ip::make_address_v4(broadcasting_server_parameters.address),
                         broadcasting_server_parameters.port)},
       broadcasting_server_parameters_{broadcasting_server_parameters},
-      strand_{asio::make_strand(io_context)} {
-  SPDLOG_INFO("Creating {}", name());
+      strand_{asio::make_strand(io_context)}, epoch_{std::random_device{}()} {
+  SPDLOG_INFO("Creating {} (protocol epoch={})", name(), epoch_);
 
   socket_->open(udp::v4());
   if (!socket_->is_open()) {
@@ -67,7 +68,7 @@ void TempoBroadcaster::broadcast_next_beat(uint64_t next_beat_time_ref, uint32_t
 
   asio::post(strand_, [this, next_beat_time_ref, beat_count]() {
     uint16_t seq = next_beat_seq_.fetch_add(1, std::memory_order_relaxed);
-    auto buffer = std::make_unique<NextBeatBuffer>(next_beat_time_ref, beat_count, seq);
+    auto buffer = std::make_unique<NextBeatBuffer>(next_beat_time_ref, beat_count, seq, epoch_);
     // Per-beat traffic — same reasoning as application.cpp.
     SPDLOG_DEBUG("{} next_beat seq={} t={} count={}", name(), seq, next_beat_time_ref, beat_count);
     dispatch(std::move(buffer));
@@ -82,7 +83,7 @@ void TempoBroadcaster::broadcast_beat(uint64_t beat_time_ref, uint32_t beat_coun
 
   asio::post(strand_, [this, beat_time_ref, beat_count]() {
     uint16_t seq = beat_seq_.fetch_add(1, std::memory_order_relaxed);
-    auto buffer = std::make_unique<BeatBuffer>(beat_time_ref, beat_count, seq);
+    auto buffer = std::make_unique<BeatBuffer>(beat_time_ref, beat_count, seq, epoch_);
     dispatch(std::move(buffer));
   });
 }
@@ -97,7 +98,7 @@ void TempoBroadcaster::push_program_now() {
     SPDLOG_INFO("{} program push seq={} pid={}", name(), seq, pid);
 
     // Immediate send.
-    dispatch(std::make_unique<ProgramPushBuffer>(pid, seq));
+    dispatch(std::make_unique<ProgramPushBuffer>(pid, seq, epoch_));
 
     // Retry 50 ms later with the same seq so controllers that already
     // applied the first packet treat the retry as an idempotent no-op
@@ -112,7 +113,7 @@ void TempoBroadcaster::push_program_now() {
           if (ec || !is_running()) {
             return;
           }
-          dispatch(std::make_unique<ProgramPushBuffer>(pid, seq));
+          dispatch(std::make_unique<ProgramPushBuffer>(pid, seq, epoch_));
         }));
   });
 }

--- a/server/src/server/udp/include/udp/udp_buffer.hpp
+++ b/server/src/server/udp/include/udp/udp_buffer.hpp
@@ -74,17 +74,17 @@ public:
 
 class NextBeatBuffer : public ResponseBuffer<beatled_message_next_beat_t> {
 public:
-  NextBeatBuffer(uint64_t next_beat_time_ref, uint32_t beat_count, uint16_t seq);
+  NextBeatBuffer(uint64_t next_beat_time_ref, uint32_t beat_count, uint16_t seq, uint32_t epoch);
 };
 
 class BeatBuffer : public ResponseBuffer<beatled_message_beat_t> {
 public:
-  BeatBuffer(uint64_t beat_time_ref, uint32_t beat_count, uint16_t seq);
+  BeatBuffer(uint64_t beat_time_ref, uint32_t beat_count, uint16_t seq, uint32_t epoch);
 };
 
 class ProgramPushBuffer : public ResponseBuffer<beatled_message_program_t> {
 public:
-  ProgramPushBuffer(uint16_t program_id, uint16_t seq);
+  ProgramPushBuffer(uint16_t program_id, uint16_t seq, uint32_t epoch);
 };
 
 // Server-initiated STATUS probe. The 8-byte `server_send_time_us` is

--- a/server/src/server/udp/udp_response_buffer.cpp
+++ b/server/src/server/udp/udp_response_buffer.cpp
@@ -45,31 +45,35 @@ TempoResponseBuffer::TempoResponseBuffer(uint64_t beat_time_ref, uint32_t tempo_
   set_data(tempo_msg);
 }
 
-NextBeatBuffer::NextBeatBuffer(uint64_t next_beat_time_ref, uint32_t beat_count, uint16_t seq) {
+NextBeatBuffer::NextBeatBuffer(uint64_t next_beat_time_ref, uint32_t beat_count, uint16_t seq,
+                               uint32_t epoch) {
   beatled_message_next_beat_t msg;
   msg.base.type = BEATLED_MESSAGE_NEXT_BEAT;
   msg.next_beat_time_ref = htonll(next_beat_time_ref);
   msg.beat_count = htonl(beat_count);
   msg.seq = htons(seq);
+  msg.epoch = htonl(epoch);
 
   set_data(msg);
 }
 
-BeatBuffer::BeatBuffer(uint64_t beat_time_ref, uint32_t beat_count, uint16_t seq) {
+BeatBuffer::BeatBuffer(uint64_t beat_time_ref, uint32_t beat_count, uint16_t seq, uint32_t epoch) {
   beatled_message_beat_t msg;
   msg.base.type = BEATLED_MESSAGE_BEAT;
   msg.beat_time_ref = htonll(beat_time_ref);
   msg.beat_count = htonl(beat_count);
   msg.seq = htons(seq);
+  msg.epoch = htonl(epoch);
 
   set_data(msg);
 }
 
-ProgramPushBuffer::ProgramPushBuffer(uint16_t program_id, uint16_t seq) {
+ProgramPushBuffer::ProgramPushBuffer(uint16_t program_id, uint16_t seq, uint32_t epoch) {
   beatled_message_program_t msg;
   msg.base.type = BEATLED_MESSAGE_PROGRAM;
   msg.program_id = htons(program_id);
   msg.seq = htons(seq);
+  msg.epoch = htonl(epoch);
 
   set_data(msg);
 }

--- a/server/tests/udp/test_udp_protocol.cpp
+++ b/server/tests/udp/test_udp_protocol.cpp
@@ -17,15 +17,13 @@ TEST_CASE("ErrorResponseBuffer serialization", "[udp][protocol]") {
     REQUIRE(buf.size() == sizeof(beatled_message_error_t));
     REQUIRE(buf.type() == BEATLED_MESSAGE_ERROR);
 
-    const auto *msg =
-        reinterpret_cast<const beatled_message_error_t *>(&buf.data());
+    const auto *msg = reinterpret_cast<const beatled_message_error_t *>(&buf.data());
     REQUIRE(msg->error_code == BEATLED_ERROR_NO_DATA);
   }
 
   SECTION("Different error codes are preserved") {
     ErrorResponseBuffer buf(BEATLED_ERROR_UNKNOWN_MESSAGE_TYPE);
-    const auto *msg =
-        reinterpret_cast<const beatled_message_error_t *>(&buf.data());
+    const auto *msg = reinterpret_cast<const beatled_message_error_t *>(&buf.data());
     REQUIRE(msg->error_code == BEATLED_ERROR_UNKNOWN_MESSAGE_TYPE);
   }
 }
@@ -39,8 +37,7 @@ TEST_CASE("HelloResponseBuffer serialization", "[udp][protocol]") {
   REQUIRE(buf.size() == sizeof(beatled_message_hello_response_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_HELLO_RESPONSE);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_hello_response_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_hello_response_t *>(&buf.data());
   REQUIRE(ntohs(msg->client_id) == client_id);
 }
 
@@ -56,8 +53,7 @@ TEST_CASE("TimeResponseBuffer serialization", "[udp][protocol]") {
   REQUIRE(buf.size() == sizeof(beatled_message_time_response_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_TIME_RESPONSE);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_time_response_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_time_response_t *>(&buf.data());
   REQUIRE(ntohll(msg->orig_time) == orig);
   REQUIRE(ntohll(msg->recv_time) == recv);
   REQUIRE(ntohll(msg->xmit_time) == xmit);
@@ -75,8 +71,7 @@ TEST_CASE("TempoResponseBuffer serialization", "[udp][protocol]") {
   REQUIRE(buf.size() == sizeof(beatled_message_tempo_response_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_TEMPO_RESPONSE);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_tempo_response_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_tempo_response_t *>(&buf.data());
   REQUIRE(ntohll(msg->beat_time_ref) == beat_time_ref);
   REQUIRE(ntohl(msg->tempo_period_us) == tempo_period_us);
   REQUIRE(ntohs(msg->program_id) == program_id);
@@ -88,17 +83,18 @@ TEST_CASE("NextBeatBuffer serialization", "[udp][protocol]") {
   uint64_t next_beat_time_ref = 9999999ULL;
   uint32_t beat_count = 100;
   uint16_t seq = 12345;
+  uint32_t epoch = 0xABCD1234;
 
-  NextBeatBuffer buf(next_beat_time_ref, beat_count, seq);
+  NextBeatBuffer buf(next_beat_time_ref, beat_count, seq, epoch);
 
   REQUIRE(buf.size() == sizeof(beatled_message_next_beat_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_NEXT_BEAT);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_next_beat_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_next_beat_t *>(&buf.data());
   REQUIRE(ntohll(msg->next_beat_time_ref) == next_beat_time_ref);
   REQUIRE(ntohl(msg->beat_count) == beat_count);
   REQUIRE(ntohs(msg->seq) == seq);
+  REQUIRE(ntohl(msg->epoch) == epoch);
 }
 
 // --- BeatBuffer ---
@@ -107,17 +103,18 @@ TEST_CASE("BeatBuffer serialization", "[udp][protocol]") {
   uint64_t beat_time_ref = 8888888ULL;
   uint32_t beat_count = 50;
   uint16_t seq = 4242;
+  uint32_t epoch = 0x0BADF00D;
 
-  BeatBuffer buf(beat_time_ref, beat_count, seq);
+  BeatBuffer buf(beat_time_ref, beat_count, seq, epoch);
 
   REQUIRE(buf.size() == sizeof(beatled_message_beat_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_BEAT);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_beat_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_beat_t *>(&buf.data());
   REQUIRE(ntohll(msg->beat_time_ref) == beat_time_ref);
   REQUIRE(ntohl(msg->beat_count) == beat_count);
   REQUIRE(ntohs(msg->seq) == seq);
+  REQUIRE(ntohl(msg->epoch) == epoch);
 }
 
 // --- ProgramPushBuffer ---
@@ -125,16 +122,17 @@ TEST_CASE("BeatBuffer serialization", "[udp][protocol]") {
 TEST_CASE("ProgramPushBuffer serialization", "[udp][protocol]") {
   uint16_t program_id = 5;
   uint16_t seq = 7;
+  uint32_t epoch = 0xDEADBEEF;
 
-  ProgramPushBuffer buf(program_id, seq);
+  ProgramPushBuffer buf(program_id, seq, epoch);
 
   REQUIRE(buf.size() == sizeof(beatled_message_program_t));
   REQUIRE(buf.type() == BEATLED_MESSAGE_PROGRAM);
 
-  const auto *msg =
-      reinterpret_cast<const beatled_message_program_t *>(&buf.data());
+  const auto *msg = reinterpret_cast<const beatled_message_program_t *>(&buf.data());
   REQUIRE(ntohs(msg->program_id) == program_id);
   REQUIRE(ntohs(msg->seq) == seq);
+  REQUIRE(ntohl(msg->epoch) == epoch);
 }
 
 // --- UDPRequestBuffer ---
@@ -153,8 +151,7 @@ TEST_CASE("UDPRequestBuffer size validation", "[udp][protocol]") {
   }
 
   SECTION("Overflow throws") {
-    REQUIRE_THROWS_AS(buf.setSize(DataBuffer::BUFFER_SIZE + 1),
-                      std::overflow_error);
+    REQUIRE_THROWS_AS(buf.setSize(DataBuffer::BUFFER_SIZE + 1), std::overflow_error);
   }
 }
 


### PR DESCRIPTION
## The bug

The broadcaster's `seq` counters are per-process atomics that reset to 0 on every server restart, while a controller's last-seen `seq` persists as long as it stays powered. After a server restart, a still-running controller saw the low post-restart seqs as "older than what we applied" (`delta < 0`) and **rejected every fresh PROGRAM/NEXT_BEAT** until the counter climbed back past its stored value — at the 5 Hz refresh that strands a controller on the wrong pattern (and stops re-anchoring its beat grid) for up to ~an hour. This presented as "controllers sometimes don't sync after a restart," and looked like packet loss but wasn't.

## The fix

Carry a 32-bit `epoch`, chosen randomly once at broadcaster construction, on every NEXT_BEAT, PROGRAM, and BEAT. Controllers scope their `seq` comparison to the current epoch and adopt the incoming `seq` unconditionally when the epoch changes — so a server restart re-anchors instead of stranding. The `seq` reset is now self-healing.

## Wire change — coordinate the rollout ⚠️

`BEATLED_PROTOCOL_VERSION_MAJOR` 4 → **5**. The server rejects controllers with a mismatched major at HELLO, so **the server and the entire controller fleet must be updated together**; un-reflashed controllers stop registering until reflashed. (No client changes — React/iOS/macOS only use the HTTP API.)

Message sizes: PROGRAM 5→9 B, NEXT_BEAT/BEAT 15→19 B.

## Tests

- Server catch2: all pass (handshake now negotiates v5.0, rejects v6.0; epoch round-trips in the three buffer serialization tests).
- Controller POSIX: all 9 suites pass, including updated `test_protocol` sizes and a **new `test_integration` regression test** proving the epoch reset (high seq applies → lower seq same epoch rejected as stale → lower seq in a new epoch applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)