### PR TITLE
Move theme control into a renamed Settings page on all clients

### DIFF
--- a/client/src/components/bottom-nav.tsx
+++ b/client/src/components/bottom-nav.tsx
@@ -1,12 +1,8 @@
 import { NavLink } from "react-router-dom";
 import { cn } from "@/lib/utils";
 import { NAVBAR_ROUTES } from "@/lib/navbar";
-import { Sun, Moon } from "lucide-react";
-import { useTheme } from "@/hooks/use-theme";
 
 export default function BottomNav() {
-  const { theme, toggle } = useTheme();
-
   return (
     <nav className="fixed bottom-0 left-0 right-0 z-50 border-t border-border bg-card/95 backdrop-blur-sm safe-bottom">
       <div className="mx-auto flex h-16 max-w-5xl items-stretch justify-around">
@@ -30,15 +26,6 @@ export default function BottomNav() {
             )}
           </NavLink>
         ))}
-        <button
-          type="button"
-          onClick={toggle}
-          className="flex flex-col items-center justify-center gap-0.5 px-4 text-[11px] font-medium text-muted-foreground transition-colors"
-          aria-label="Toggle theme"
-        >
-          {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
-          <span>Theme</span>
-        </button>
       </div>
     </nav>
   );

--- a/client/src/hooks/__tests__/use-theme.test.ts
+++ b/client/src/hooks/__tests__/use-theme.test.ts
@@ -4,11 +4,13 @@ import { renderHook, act } from "@testing-library/react";
 describe("useTheme", () => {
   let store: Record<string, string> = {};
   let matchMediaResult = false;
+  let changeHandler: (() => void) | null = null;
 
   beforeEach(() => {
     store = {};
     document.documentElement.classList.remove("dark");
     matchMediaResult = false;
+    changeHandler = null;
 
     vi.stubGlobal("localStorage", {
       getItem: vi.fn((key: string) => store[key] ?? null),
@@ -25,7 +27,9 @@ describe("useTheme", () => {
       vi.fn((query: string) => ({
         matches: matchMediaResult,
         media: query,
-        addEventListener: vi.fn(),
+        addEventListener: vi.fn((_event: string, handler: () => void) => {
+          changeHandler = handler;
+        }),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),
       })),
@@ -37,58 +41,92 @@ describe("useTheme", () => {
     vi.resetModules();
   });
 
-  it("defaults to light when system prefers light", async () => {
+  it("defaults to the system preference, resolving light when OS prefers light", async () => {
     matchMediaResult = false;
     const { useTheme } = await import("../use-theme");
     const { result } = renderHook(() => useTheme());
 
-    expect(result.current.theme).toBe("light");
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolvedTheme).toBe("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
-  it("defaults to dark when system prefers dark", async () => {
+  it("resolves dark under the system preference when OS prefers dark", async () => {
     matchMediaResult = true;
     const { useTheme } = await import("../use-theme");
     const { result } = renderHook(() => useTheme());
 
-    expect(result.current.theme).toBe("dark");
+    expect(result.current.preference).toBe("system");
+    expect(result.current.resolvedTheme).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("reads stored theme from localStorage", async () => {
+  it("reads a stored explicit preference from localStorage", async () => {
     store["beatled_theme"] = "dark";
     const { useTheme } = await import("../use-theme");
     const { result } = renderHook(() => useTheme());
 
-    expect(result.current.theme).toBe("dark");
+    expect(result.current.preference).toBe("dark");
+    expect(result.current.resolvedTheme).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("toggles from light to dark", async () => {
+  it("setTheme('dark') persists and applies the dark class", async () => {
     matchMediaResult = false;
     const { useTheme } = await import("../use-theme");
     const { result } = renderHook(() => useTheme());
 
     act(() => {
-      result.current.toggle();
+      result.current.setTheme("dark");
     });
 
-    expect(result.current.theme).toBe("dark");
+    expect(result.current.preference).toBe("dark");
     expect(store["beatled_theme"]).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 
-  it("toggles from dark to light", async () => {
+  it("setTheme('light') persists and removes the dark class", async () => {
     store["beatled_theme"] = "dark";
     const { useTheme } = await import("../use-theme");
     const { result } = renderHook(() => useTheme());
 
     act(() => {
-      result.current.toggle();
+      result.current.setTheme("light");
     });
 
-    expect(result.current.theme).toBe("light");
+    expect(result.current.preference).toBe("light");
     expect(store["beatled_theme"]).toBe("light");
     expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("setTheme('system') resolves against the OS preference", async () => {
+    store["beatled_theme"] = "light";
+    matchMediaResult = true; // OS prefers dark
+    const { useTheme } = await import("../use-theme");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => {
+      result.current.setTheme("system");
+    });
+
+    expect(result.current.preference).toBe("system");
+    expect(store["beatled_theme"]).toBe("system");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("follows live OS changes while the preference is 'system'", async () => {
+    matchMediaResult = false;
+    const { useTheme } = await import("../use-theme");
+    renderHook(() => useTheme());
+
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    // Simulate the OS flipping to dark and firing the media-query change event.
+    act(() => {
+      matchMediaResult = true;
+      changeHandler?.();
+    });
+
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 });

--- a/client/src/hooks/use-theme.ts
+++ b/client/src/hooks/use-theme.ts
@@ -1,23 +1,41 @@
 import { useCallback, useSyncExternalStore } from "react";
 
-type Theme = "light" | "dark";
+export type ThemePreference = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
 
 const STORAGE_KEY = "beatled_theme";
 
-function getSystemTheme(): Theme {
-  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+function prefersDark(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
 }
 
-function getStoredTheme(): Theme {
-  return (localStorage.getItem(STORAGE_KEY) as Theme) || getSystemTheme();
+function getStoredPreference(): ThemePreference {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  // Anything legacy/unknown (the old binary store only ever wrote
+  // "light"/"dark", which still validate here) falls back to "system".
+  return stored === "light" || stored === "dark" || stored === "system"
+    ? stored
+    : "system";
 }
 
-function applyTheme(theme: Theme) {
-  document.documentElement.classList.toggle("dark", theme === "dark");
+function resolveTheme(preference: ThemePreference): ResolvedTheme {
+  if (preference === "system") return prefersDark() ? "dark" : "light";
+  return preference;
+}
+
+function applyTheme(preference: ThemePreference) {
+  document.documentElement.classList.toggle(
+    "dark",
+    resolveTheme(preference) === "dark",
+  );
 }
 
 // Apply on load (before React hydrates)
-applyTheme(getStoredTheme());
+applyTheme(getStoredPreference());
 
 let listeners: Array<() => void> = [];
 
@@ -25,6 +43,21 @@ function emitChange() {
   for (const listener of listeners) {
     listener();
   }
+}
+
+// While the preference is "system", track live OS theme changes so the
+// document class follows them without a reload. The stored preference doesn't
+// change, so subscribers won't re-render — but applyTheme keeps the DOM in
+// sync, which is what actually drives the visible theme.
+if (typeof window !== "undefined" && typeof window.matchMedia === "function") {
+  window
+    .matchMedia("(prefers-color-scheme: dark)")
+    .addEventListener("change", () => {
+      if (getStoredPreference() === "system") {
+        applyTheme("system");
+        emitChange();
+      }
+    });
 }
 
 function subscribe(listener: () => void) {
@@ -35,14 +68,13 @@ function subscribe(listener: () => void) {
 }
 
 export function useTheme() {
-  const theme = useSyncExternalStore(subscribe, getStoredTheme);
+  const preference = useSyncExternalStore(subscribe, getStoredPreference);
 
-  const toggle = useCallback(() => {
-    const next: Theme = getStoredTheme() === "dark" ? "light" : "dark";
+  const setTheme = useCallback((next: ThemePreference) => {
     localStorage.setItem(STORAGE_KEY, next);
     applyTheme(next);
     emitChange();
   }, []);
 
-  return { theme, toggle } as const;
+  return { preference, resolvedTheme: resolveTheme(preference), setTheme } as const;
 }

--- a/client/src/lib/navbar.tsx
+++ b/client/src/lib/navbar.tsx
@@ -23,7 +23,7 @@ export const NAVBAR_ROUTES: NavRoute[] = [
     icon: <ScrollText className="h-5 w-5" />,
   },
   {
-    name: "Config",
+    name: "Settings",
     path: "/config",
     icon: <Settings className="h-5 w-5" />,
   },

--- a/client/src/test/setup.ts
+++ b/client/src/test/setup.ts
@@ -11,3 +11,48 @@ class ResizeObserverStub {
 if (typeof globalThis.ResizeObserver === "undefined") {
   globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
 }
+
+// The theme hook (now imported by the Settings view) reads localStorage at
+// module load. This environment's localStorage isn't a working Storage (its
+// methods aren't callable), so provide a minimal in-memory implementation.
+if (
+  typeof window !== "undefined" &&
+  typeof window.localStorage?.getItem !== "function"
+) {
+  const mem = new Map<string, string>();
+  const stub: Storage = {
+    get length() {
+      return mem.size;
+    },
+    clear: () => mem.clear(),
+    getItem: (key: string) => mem.get(key) ?? null,
+    key: (index: number) => Array.from(mem.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      mem.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      mem.set(key, String(value));
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: stub,
+    configurable: true,
+  });
+}
+
+// jsdom has no matchMedia; the theme hook (now imported by the Settings view)
+// queries prefers-color-scheme at module load. Provide a light-mode stub so
+// any view that pulls in useTheme can mount. The dedicated use-theme test
+// overrides this with its own controllable mock.
+if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}

--- a/client/src/views/config.tsx
+++ b/client/src/views/config.tsx
@@ -15,6 +15,8 @@ import {
 } from "../lib/api";
 import { apControl } from "../lib/ap";
 import { useInterval } from "../hooks/interval";
+import { useTheme, type ThemePreference } from "../hooks/use-theme";
+import { Monitor, Sun, Moon } from "lucide-react";
 
 export async function loader() {
   return { host: getAPIHost(), token: getAPIToken() };
@@ -194,6 +196,43 @@ function AccessPointCard() {
   );
 }
 
+const APPEARANCE_OPTIONS: {
+  value: ThemePreference;
+  label: string;
+  icon: React.ReactNode;
+}[] = [
+  { value: "system", label: "System", icon: <Monitor className="h-4 w-4" /> },
+  { value: "light", label: "Light", icon: <Sun className="h-4 w-4" /> },
+  { value: "dark", label: "Dark", icon: <Moon className="h-4 w-4" /> },
+];
+
+function AppearanceCard() {
+  const { preference, setTheme } = useTheme();
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-3">
+        <Label className="text-sm font-medium">Appearance</Label>
+        <div className="grid grid-cols-3 gap-2">
+          {APPEARANCE_OPTIONS.map((opt) => (
+            <Button
+              key={opt.value}
+              type="button"
+              variant={preference === opt.value ? "default" : "outline"}
+              aria-pressed={preference === opt.value}
+              onClick={() => setTheme(opt.value)}
+              className="flex items-center justify-center gap-2"
+            >
+              {opt.icon}
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function ConfigPage() {
   const submit = useSubmit();
   const { host, token } = useLoaderData() as { host: string; token: string };
@@ -230,8 +269,9 @@ export default function ConfigPage() {
 
   return (
     <>
-      <PageHeader title="Config" />
+      <PageHeader title="Settings" />
       <div className="px-4 pb-8 md:px-8 space-y-4">
+        <AppearanceCard />
         <Card>
           <CardContent className="pt-6">
             <fieldset>

--- a/ios/Beatled/BeatledApp.swift
+++ b/ios/Beatled/BeatledApp.swift
@@ -21,6 +21,7 @@ struct BeatledApp: App {
                 .environment(apiClient)
                 .environment(configViewModel)
                 .tint(Color("AccentColor"))
+                .preferredColorScheme(settings.appearance.colorScheme)
                 .task { await configViewModel.runHealthChecks() }
         }
         #if os(macOS)

--- a/ios/Beatled/ContentView.swift
+++ b/ios/Beatled/ContentView.swift
@@ -20,7 +20,7 @@ struct ContentView: View {
             Tab("Log", systemImage: "text.alignleft") {
                 LogView(viewModel: LogViewModel(api: api))
             }
-            Tab("Config", systemImage: "gearshape") {
+            Tab("Settings", systemImage: "gearshape") {
                 ConfigView(viewModel: configViewModel)
             }
         }

--- a/ios/Beatled/Services/AppSettings.swift
+++ b/ios/Beatled/Services/AppSettings.swift
@@ -1,4 +1,31 @@
 import Foundation
+import SwiftUI
+
+/// User's preferred appearance, mirroring the web client's System/Light/Dark
+/// control so all three clients expose the same choice.
+enum AppearancePreference: String, CaseIterable, Identifiable {
+    case system, light, dark
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .system: "System"
+        case .light: "Light"
+        case .dark: "Dark"
+        }
+    }
+
+    /// nil follows the OS appearance; otherwise force the scheme via
+    /// `.preferredColorScheme`.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: nil
+        case .light: .light
+        case .dark: .dark
+        }
+    }
+}
 
 @Observable
 class AppSettings {
@@ -24,6 +51,9 @@ class AppSettings {
     var allowInsecureConnections: Bool {
         didSet { defaults.set(allowInsecureConnections, forKey: "allowInsecureConnections") }
     }
+    var appearance: AppearancePreference {
+        didSet { defaults.set(appearance.rawValue, forKey: "appearance") }
+    }
 
     init(tokenStore: TokenStore = KeychainTokenStore(), defaults: UserDefaults = .standard) {
         self.tokenStore = tokenStore
@@ -45,5 +75,7 @@ class AppSettings {
 
         self.apiToken = tokenStore.load() ?? ""
         self.allowInsecureConnections = defaults.bool(forKey: "allowInsecureConnections")
+        self.appearance = AppearancePreference(
+            rawValue: defaults.string(forKey: "appearance") ?? "") ?? .system
     }
 }

--- a/ios/Beatled/Views/ConfigView.swift
+++ b/ios/Beatled/Views/ConfigView.swift
@@ -8,6 +8,7 @@ struct ConfigView: View {
     var body: some View {
         NavigationStack {
             Form {
+                appearanceSection
                 serverSection
                 authenticationSection
                 securitySection
@@ -15,7 +16,7 @@ struct ConfigView: View {
                 aboutSection
             }
             .formStyle(.grouped)
-            .navigationTitle("Config")
+            .navigationTitle("Settings")
             .alert("Security Warning", isPresented: $showInsecureWarning) {
                 Button("Cancel", role: .cancel) {
                     viewModel.settings.allowInsecureConnections = false
@@ -36,6 +37,19 @@ struct ConfigView: View {
                        ? " The Pi auto-reverts to WiFi after \(viewModel.revertMinutes) min."
                        : ""))
             }
+        }
+    }
+
+    @ViewBuilder
+    private var appearanceSection: some View {
+        Section("Appearance") {
+            Picker("Theme", selection: $viewModel.settings.appearance) {
+                ForEach(AppearancePreference.allCases) { preference in
+                    Text(preference.label).tag(preference)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
         }
     }
 

--- a/ios/Beatled/Views/MacContentView.swift
+++ b/ios/Beatled/Views/MacContentView.swift
@@ -3,17 +3,17 @@ import SwiftUI
 
 enum SidebarItem: String, CaseIterable, Identifiable {
     // Program first, matching the web client's default route.
-    case program, status, log, config
+    case program, status, log, settings
     var id: Self { self }
 
     var label: String { rawValue.capitalized }
 
     var icon: String {
         switch self {
-        case .program: "music.note"
-        case .status:  "waveform.path"
-        case .log:     "text.alignleft"
-        case .config:  "gearshape"
+        case .program:  "music.note"
+        case .status:   "waveform.path"
+        case .log:      "text.alignleft"
+        case .settings: "gearshape"
         }
     }
 }
@@ -36,10 +36,10 @@ struct MacContentView: View {
                     viewModel: ProgramViewModel(api: api),
                     statusViewModel: StatusViewModel(api: api)
                 )
-            case .status:  StatusView(viewModel: StatusViewModel(api: api))
-            case .log:     LogView(viewModel: LogViewModel(api: api))
-            case .config:  ConfigView(viewModel: configViewModel)
-            case nil:      Text("Select a view")
+            case .status:   StatusView(viewModel: StatusViewModel(api: api))
+            case .log:      LogView(viewModel: LogViewModel(api: api))
+            case .settings: ConfigView(viewModel: configViewModel)
+            case nil:       Text("Select a view")
             }
         }
     }

--- a/ios/BeatledTests/AppSettingsTests.swift
+++ b/ios/BeatledTests/AppSettingsTests.swift
@@ -125,4 +125,23 @@ final class AppSettingsTests: XCTestCase {
         let reloaded = AppSettings(tokenStore: InMemoryTokenStore(), defaults: defaults)
         XCTAssertTrue(reloaded.allowInsecureConnections)
     }
+
+    // MARK: Appearance persistence
+
+    func testAppearanceDefaultsToSystemAndPersists() {
+        let settings = AppSettings(tokenStore: InMemoryTokenStore(), defaults: defaults)
+        XCTAssertEqual(settings.appearance, .system)
+
+        settings.appearance = .dark
+        XCTAssertEqual(defaults.string(forKey: "appearance"), "dark")
+
+        let reloaded = AppSettings(tokenStore: InMemoryTokenStore(), defaults: defaults)
+        XCTAssertEqual(reloaded.appearance, .dark)
+    }
+
+    func testUnknownStoredAppearanceFallsBackToSystem() {
+        defaults.set("chartreuse", forKey: "appearance")
+        let settings = AppSettings(tokenStore: InMemoryTokenStore(), defaults: defaults)
+        XCTAssertEqual(settings.appearance, .system)
+    }
 }


### PR DESCRIPTION
## Summary

Moves the appearance control out of the web client's bottom nav and onto the page, and renames "Config" → "Settings" so React, iOS, and macOS expose the same Settings surface with the same System / Light / Dark control.

## Changes

**React**
- `use-theme`: binary light/dark toggle → `light`/`dark`/`system` preference; `system` follows the OS and tracks live `prefers-color-scheme` changes.
- Removed the theme button from the bottom nav; added an **Appearance** card to the Settings page.
- Renamed the nav tab + page header "Config" → "Settings".
- Test setup gains `matchMedia` + `localStorage` stubs (the Settings view now imports the theme hook at module load).

**iOS / macOS**
- New `AppearancePreference` (System/Light/Dark) persisted in `AppSettings`, applied via `.preferredColorScheme` at the app root.
- Added an **Appearance** section to the settings form.
- Renamed the tab / sidebar / nav title "Config" → "Settings".

User-facing strings only — routes (`/config`), view types, and view-model names keep their `config` identifiers to limit blast radius.

## Tests
- React: full suite green (72/72), `tsc --noEmit` clean; rewrote the use-theme test for the new preference API.
- iOS/macOS: macOS build compiles; iOS simulator build + unit tests `TEST SUCCEEDED`, including new `AppSettings` appearance-persistence tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)