### PR TITLE
Pin deploy builder vcpkg to the manifest baseline (2026.01.16)

### DIFF
--- a/docker/Dockerfile.builder
+++ b/docker/Dockerfile.builder
@@ -30,10 +30,14 @@ RUN dpkg --add-architecture arm64 \
   # autoconf libtool
 
 ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+# Pin to the same vcpkg commit as server/vcpkg.json's builtin-baseline and
+# .github/workflows/server-ci.yml so the cross-compiled deploy binary is built
+# against the same library versions that CI and native builds test against.
+# This SHA is the vcpkg release tag 2026.01.16.
 RUN cd /tmp \
-    && git clone https://github.com/Microsoft/vcpkg.git -n \ 
+    && git clone https://github.com/Microsoft/vcpkg.git -n \
     && cd vcpkg \
-    && git checkout b216ddff25a1f432870e6c340ce79357049ef86e \
+    && git checkout 66c0373dc7fca549e5803087b9487edfe3aca0a1 \
     && ./bootstrap-vcpkg.sh
 
 COPY server/cmake/arm64-linux-custom.cmake /tmp/vcpkg/triplets


### PR DESCRIPTION
## Summary

Removes vcpkg pin drift between the build paths. `docker/Dockerfile.builder` cross-compiled the ARM64 server against vcpkg commit `b216ddff` (classic mode, hand-maintained package list), while `server/vcpkg.json`'s `builtin-baseline` and `server-ci.yml`'s `vcpkgGitCommitId` both use `66c0373` — the vcpkg release tag **2026.01.16**. So the deployed Pi binary was built against a different, untested-against set of library versions than CI and native builds.

This points the builder at `66c0373` so manifest, CI, and deploy all resolve to the same vcpkg release.

## Not a version bump

Investigation showed the manifest is **already on the latest vcpkg release** (`2026.01.16` = `66c0373`). Of the 15 server deps, only 3 have moved on *untagged* master since (openssl 3.6.0→3.6.1, kissfft 131.1→131.2, portaudio packaging) — not worth leaving a tagged release for. This PR only removes the drift; no dependency versions change for CI/native.

## Verification

Full `./beatled.sh build rpi` cross-compile at `66c0373` succeeded — all `arm64-linux-custom` ports (including the fragile openssl/fftw/portaudio) rebuilt cleanly, producing a valid aarch64 `beat_server`. `b216ddff` was not a load-bearing pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)