### PR TITLE
Show server + controller uptime (status page, all clients)

### DIFF
--- a/client/src/lib/status.ts
+++ b/client/src/lib/status.ts
@@ -12,6 +12,8 @@ export interface StatusResponse {
   // the server returns from /api/status and /api/tempo/manual.
   manualBpm?: number;
   deviceCount?: number;
+  // Microseconds since the server process started (time since last restart).
+  uptime_us?: number;
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -25,6 +27,7 @@ export function isStatusResponse(v: unknown): v is StatusResponse {
   if (v.tempo !== undefined && typeof v.tempo !== "number") return false;
   if (v.manualBpm !== undefined && typeof v.manualBpm !== "number") return false;
   if (v.deviceCount !== undefined && typeof v.deviceCount !== "number") return false;
+  if (v.uptime_us !== undefined && typeof v.uptime_us !== "number") return false;
   if (
     v.status !== undefined &&
     typeof v.status !== "string" &&

--- a/client/src/views/status.tsx
+++ b/client/src/views/status.tsx
@@ -1,5 +1,5 @@
 import { useFetcher } from "react-router-dom";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useInterval } from "../hooks/interval";
 import { getStatus, getDevices, getQos, serviceControl, type Device, type FleetQos } from "../lib/status";
 import PageHeader from "../components/page-header";
@@ -25,6 +25,27 @@ interface TempoHistoryEntry {
   status?: string | boolean | Record<string, boolean>;
   tempo?: number;
   deviceCount?: number;
+  uptime_us?: number;
+}
+
+// Compact duration: "3d 4h", "4h 12m", "12m 5s", "5s".
+function formatDurationUs(us: number): string {
+  const totalSec = Math.floor(us / 1_000_000);
+  const d = Math.floor(totalSec / 86400);
+  const h = Math.floor((totalSec % 86400) / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+// Controller time-since-boot, reported in the QoS block (uptime_us).
+function formatDeviceUptime(device: Device): string {
+  const us = device.qos?.uptime_us;
+  if (us === undefined || us === null) return "—";
+  return formatDurationUs(us);
 }
 
 export async function loader() {
@@ -195,6 +216,12 @@ function FleetQosCard({ qos }: FleetQosCardProps) {
 export default function StatusPage() {
   const fetcher = useFetcher();
 
+  // Drives the live server-uptime display. The status data itself is polled
+  // by the 2s fetcher below; this 30s tick re-renders so the uptime keeps
+  // counting up between polls (and refreshes at least every 30s, per spec).
+  const [now, setNow] = useState(() => Date.now());
+  useInterval(() => setNow(Date.now()), 30 * 1000);
+
   useInterval(() => {
     if (fetcher.state === "idle") {
       fetcher.submit(null);
@@ -222,6 +249,13 @@ export default function StatusPage() {
   const data = fetcherData?.last || ({} as Partial<TempoHistoryEntry>);
   const devices = fetcherData?.devices || [];
   const qos = fetcherData?.qos ?? null;
+
+  // Server "time since last restart". uptime_us is sampled at fetch time
+  // (data.x); extrapolate to the current `now` tick so it counts up live.
+  const serverUptime =
+    data.uptime_us !== undefined && data.x
+      ? formatDurationUs(data.uptime_us + Math.max(0, now - data.x.getTime()) * 1000)
+      : null;
 
   return (
     <>
@@ -265,6 +299,10 @@ export default function StatusPage() {
                           />
                         )}
                       </TableCell>
+                    </TableRow>
+                    <TableRow>
+                      <TableCell className="font-medium">Uptime</TableCell>
+                      <TableCell className="text-right">{serverUptime ?? "—"}</TableCell>
                     </TableRow>
                     <TableRow>
                       <TableCell className="font-medium">Devices</TableCell>
@@ -316,6 +354,7 @@ export default function StatusPage() {
                     <TableHead className="text-right">Offset</TableHead>
                     <TableHead className="text-right">RTT</TableHead>
                     <TableHead className="text-right">NB gaps</TableHead>
+                    <TableHead className="text-right">Uptime</TableHead>
                     <TableHead className="text-right">Last Seen</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -335,6 +374,9 @@ export default function StatusPage() {
                       </TableCell>
                       <TableCell className="text-right font-mono text-xs">
                         {formatLoss(device)}
+                      </TableCell>
+                      <TableCell className="text-right font-mono text-xs">
+                        {formatDeviceUptime(device)}
                       </TableCell>
                       <TableCell className="text-right">
                         {formatLastSeen(device.last_status_time)}

--- a/docs/api.markdown
+++ b/docs/api.markdown
@@ -85,7 +85,8 @@ Returns the server health status, service states, current tempo, and connected d
   },
   "tempo": 120.5,
   "manualBpm": 120.0,
-  "deviceCount": 3
+  "deviceCount": 3,
+  "uptime_us": 9876543210
 }
 ```
 
@@ -96,6 +97,7 @@ Returns the server health status, service states, current tempo, and connected d
 | `tempo` | number | Current tempo in BPM (from whichever tempo source is active) |
 | `manualBpm` | number | Operator-chosen BPM used by the `manual-bpm` service |
 | `deviceCount` | number | Number of connected Pico W devices |
+| `uptime_us` | number | Microseconds since the server process started (time since last restart) |
 
 ---
 

--- a/ios/Beatled/Models/StatusResponse.swift
+++ b/ios/Beatled/Models/StatusResponse.swift
@@ -7,6 +7,32 @@ struct StatusResponse: Codable {
     let deviceCount: Int
     // Optional so older servers without the field still decode.
     let manualBpm: Double?
+    // Microseconds since the server process started (time since last restart).
+    // Optional so older servers without the field still decode.
+    let uptimeUs: Double?
+
+    private enum CodingKeys: String, CodingKey {
+        case message
+        case status
+        case tempo
+        case deviceCount
+        case manualBpm
+        case uptimeUs = "uptime_us"
+    }
+}
+
+// Compact duration: "3d 4h", "4h 12m", "12m 5s", "5s". Shared by the server
+// uptime row and the per-device uptime column.
+func formatDurationUs(_ us: Double) -> String {
+    let totalSec = Int(us / 1_000_000)
+    let d = totalSec / 86400
+    let h = (totalSec % 86400) / 3600
+    let m = (totalSec % 3600) / 60
+    let s = totalSec % 60
+    if d > 0 { return "\(d)d \(h)h" }
+    if h > 0 { return "\(h)h \(m)m" }
+    if m > 0 { return "\(m)m \(s)s" }
+    return "\(s)s"
 }
 
 struct DevicesResponse: Codable {
@@ -123,6 +149,12 @@ struct Device: Codable, Identifiable {
     }
 
     var id: Int { clientId }
+
+    // Controller time-since-boot from the QoS block (uptime_us).
+    var uptimeText: String {
+        guard let us = qos?.uptimeUs else { return "—" }
+        return formatDurationUs(us)
+    }
 
     var lastSeenText: String {
         let nowUs = UInt64(Date().timeIntervalSince1970 * 1_000_000)

--- a/ios/Beatled/Views/DevicesTableView.swift
+++ b/ios/Beatled/Views/DevicesTableView.swift
@@ -40,7 +40,7 @@ struct DevicesTableView: View {
         let offset = Self.signedMs(device.qos?.currentOffsetUs)
         let rtt = Self.ms(device.qos?.medianRttUs)
         let gaps = device.qos?.nextBeatGapTotal.map(String.init) ?? "—"
-        return "offset \(offset) · RTT \(rtt) · NB gaps \(gaps)"
+        return "offset \(offset) · RTT \(rtt) · NB gaps \(gaps) · up \(device.uptimeText)"
     }
 
     private static func ms(_ us: Double?) -> String {

--- a/ios/Beatled/Views/StatusView.swift
+++ b/ios/Beatled/Views/StatusView.swift
@@ -59,11 +59,32 @@ struct StatusView: View {
             }
             .padding(.vertical, 4)
 
+            serverUptimeRow
+
             if let lastUpdate = viewModel.lastUpdate {
                 HStack {
                     Image(systemName: "clock")
                         .font(.caption2)
                     Text("Updated \(lastUpdate, style: .relative) ago")
+                        .font(.caption)
+                }
+                .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    // Server "time since last restart". uptime_us is sampled at fetch time
+    // (lastUpdate); a 30s TimelineView extrapolates from that anchor so the
+    // value counts up live between the 2s data polls.
+    @ViewBuilder
+    private var serverUptimeRow: some View {
+        if let uptimeUs = viewModel.status?.uptimeUs, let anchor = viewModel.lastUpdate {
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                let liveUs = uptimeUs + max(0, context.date.timeIntervalSince(anchor)) * 1_000_000
+                HStack {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.caption2)
+                    Text("Up \(formatDurationUs(liveUs))")
                         .font(.caption)
                 }
                 .foregroundStyle(.secondary)

--- a/server/src/application.hpp
+++ b/server/src/application.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <thread>
 
+#include "core/clock.hpp"
 #include "core/config.hpp"
 #include "core/interfaces/service_manager.hpp"
 #include "core/state_manager.hpp"
@@ -25,10 +26,15 @@ public:
 
   StateManager &state_manager() override { return state_manager_; }
 
+  // Monotonic microseconds since this Application was constructed (≈ process
+  // start). Surfaced on /api/status as the server's "time since last restart".
+  uint64_t uptime_us() const override { return core::Clock::time_us_64() - start_time_us_; }
+
 private:
   void initialize_io_context();
   void start_threads();
 
+  const uint64_t start_time_us_{core::Clock::time_us_64()};
   const server::Server::parameters_t server_parameters_;
   StateManager state_manager_;
   server::Logger logger_;

--- a/server/src/core/include/core/interfaces/service_manager.hpp
+++ b/server/src/core/include/core/interfaces/service_manager.hpp
@@ -1,6 +1,7 @@
 #ifndef CORE__INTERFACES__SERVICE_MANAGER_HPP
 #define CORE__INTERFACES__SERVICE_MANAGER_HPP
 
+#include <cstdint>
 #include <fmt/format.h>
 #include <stdexcept>
 
@@ -23,6 +24,12 @@ public:
   const service_map_t &services() const { return interface_map_; }
 
   virtual StateManager &state_manager() = 0;
+
+  // Microseconds since the server process started. Defaults to 0 so test
+  // doubles needn't implement it; the real Application overrides it with a
+  // monotonic-clock delta from construction time.
+  virtual uint64_t uptime_us() const { return 0; }
+
   virtual ~ServiceManagerInterface() {}
 
 protected:

--- a/server/src/server/http/api_handler.cpp
+++ b/server/src/server/http/api_handler.cpp
@@ -113,6 +113,7 @@ APIHandler::req_status_t APIHandler::on_get_status(const req_handle_t &req, rout
   response_body["tempo"] = service_manager_.state_manager().get_tempo_ref().tempo;
   response_body["manualBpm"] = service_manager_.state_manager().get_manual_bpm();
   response_body["deviceCount"] = service_manager_.state_manager().get_clients().size();
+  response_body["uptime_us"] = service_manager_.uptime_us();
 
   return init_resp(req->create_response(restinio::status_ok()))
       .set_body(response_body.dump())

--- a/server/tests/api_handler/test_api_handler.cpp
+++ b/server/tests/api_handler/test_api_handler.cpp
@@ -54,10 +54,12 @@ TEST_CASE("API response contract: status endpoint", "[api]") {
     }
     response["status"] = service_status;
     response["tempo"] = sm.state_manager().get_tempo_ref().tempo;
+    response["uptime_us"] = sm.uptime_us();
 
     REQUIRE(response.contains("message"));
     REQUIRE(response.contains("status"));
     REQUIRE(response.contains("tempo"));
+    REQUIRE(response.contains("uptime_us"));
     REQUIRE(response["message"] == "It's all good!");
     REQUIRE(response["tempo"].get<float>() == 120.5f);
     REQUIRE(response["status"]["beat_detector"] == false);
@@ -102,15 +104,14 @@ TEST_CASE("API response contract: program endpoint", "[api]") {
 
     json response;
     response["programId"] = program_id;
-    response["programs"] = json::array(
-        {{{"name", "Snakes!"}, {"id", 0}},
-         {{"name", "Random data"}, {"id", 1}},
-         {{"name", "Sparkles"}, {"id", 2}},
-         {{"name", "Greys"}, {"id", 3}},
-         {{"name", "Drops"}, {"id", 4}},
-         {{"name", "Solid!"}, {"id", 5}},
-         {{"name", "Fade"}, {"id", 6}},
-         {{"name", "Fade Color"}, {"id", 7}}});
+    response["programs"] = json::array({{{"name", "Snakes!"}, {"id", 0}},
+                                        {{"name", "Random data"}, {"id", 1}},
+                                        {{"name", "Sparkles"}, {"id", 2}},
+                                        {{"name", "Greys"}, {"id", 3}},
+                                        {{"name", "Drops"}, {"id", 4}},
+                                        {{"name", "Solid!"}, {"id", 5}},
+                                        {{"name", "Fade"}, {"id", 6}},
+                                        {{"name", "Fade Color"}, {"id", 7}}});
 
     REQUIRE(response["programId"].get<uint16_t>() == 3);
     REQUIRE(response["programs"].is_array());


### PR DESCRIPTION
## Summary

Adds a visible **server uptime** ("time since last restart") to the status page across all three clients, plus surfaces the **controller uptime** already present in the QoS data. Three commits, in the API-stability order (server + docs → React → Swift).

## Server (`/api/status`)
- `Application` captures a monotonic start timestamp; new `ServiceManagerInterface::uptime_us()` (defaulted to 0 for test doubles) surfaces elapsed µs as **`uptime_us`** on `/api/status`.
- `docs/api.markdown` documents the field; contract test updated.

## React
- "Uptime" field on the status card (server time-since-restart from `uptime_us`), recomputed live every 30s.
- Per-device "Uptime" column (controller time-since-boot from the existing `qos.uptime_us`).
- New `formatDurationUs` helper.

## iOS / macOS
- `StatusResponse` decodes `uptime_us`; Status view shows server uptime (live via a 30s `TimelineView`); device rows show controller uptime. Shared `formatDurationUs`.

## Verification
Server catch2 tests pass; React `tsc` clean + 72/72; iOS build + unit tests `TEST SUCCEEDED` (verified during development; code unchanged since).

🤖 Generated with [Claude Code](https://claude.com/claude-code)